### PR TITLE
feat: Aether UpdateManager and title bar badge (Phases 2 & 3)

### DIFF
--- a/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
@@ -6,6 +6,7 @@ import Combine
 struct AetherApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject var tabManager = TabManager()
+    @StateObject var updateManager = UpdateManager.shared
     @ObservedObject var configManager = ConfigManager.shared
     
     // First Run Experience
@@ -44,9 +45,12 @@ struct AetherApp: App {
                                         .id(session.id.uuidString + session.windowTitle) // Redraw on session/title change
                             }
                             
-                            // Custom Button Removed
+                            // Title Bar Buttons
                             HStack {
                                 Spacer()
+                                
+                                UpdateBadgeView()
+                                    .padding(.trailing, 10)
                             }
                             .frame(height: 28)
                         }
@@ -149,6 +153,9 @@ struct AetherApp: App {
                 
                 // Trigger async session loading — does NOT block main thread
                 SessionManager.shared.loadAsync()
+                
+                // Update management
+                updateManager.schedulePeriodicCheck()
             }
             .onReceive(SessionManager.shared.$isLoaded) { loaded in
                 guard loaded else { return }

--- a/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Combine
+
+/// Numeric semantic versioning (major.minor.patch)
+struct SemanticVersion: Comparable, CustomStringConvertible {
+    let major: Int
+    let minor: Int
+    let patch: Int
+    let originalString: String
+
+    init?(_ versionString: String) {
+        let cleaned = versionString.hasPrefix("v") ? String(versionString.dropFirst()) : versionString
+        let parts = cleaned.split(separator: ".").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        
+        // Support 1.0, 1.0.0, etc.
+        guard parts.count >= 2 else { return nil }
+        
+        self.major = parts[0]
+        self.minor = parts[1]
+        self.patch = parts.count > 2 ? parts[2] : 0
+        self.originalString = versionString
+    }
+
+    var description: String { originalString }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+
+    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
+    }
+}
+
+/// Metadata returned by GET /api/v1/aether/latest
+struct AetherVersionInfo: Codable {
+    let version: String
+    let description: String
+    let changelog: String
+    let releaseDate: String
+    let size: Int64
+    let bundleFilename: String?
+    let bundleSize: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case version, description, changelog, size
+        case releaseDate = "release_date"
+        case bundleFilename = "bundle_filename"
+        case bundleSize = "bundle_size"
+    }
+}
+
+class UpdateManager: ObservableObject {
+    static let shared = UpdateManager()
+    
+    @Published var state: UpdateState = .idle
+    @Published var availableVersion: AetherVersionInfo?
+    @Published var downloadProgress: Double = 0.0
+    @Published var statusMessage: String = ""
+    
+    private var checkTimer: Timer?
+    private var cancellables = Set<AnyCancellable>()
+    
+    enum UpdateState: Equatable {
+        case idle
+        case checking
+        case available(version: String)
+        case downloading
+        case readyToInstall
+        case installing
+        case failed(error: String)
+        case restartRequired
+        
+        var isProgressState: Bool {
+            if case .downloading = self { return true }
+            if case .installing = self { return true }
+            return false
+        }
+        
+        var isFailedState: Bool {
+            if case .failed = self { return true }
+            return false
+        }
+    }
+    
+    var isFailedState: Bool { state.isFailedState }
+    
+    private init() {
+        // Log current version for debugging
+        if let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            print("[UpdateManager] Current version: \(currentVersion)")
+        }
+    }
+    
+    func schedulePeriodicCheck() {
+        checkTimer?.invalidate()
+        
+        let config = ConfigManager.shared.config.update
+        guard config.enabled else {
+            print("[UpdateManager] Updates disabled in config.")
+            return
+        }
+        
+        // Initial check
+        checkForUpdates()
+        
+        // Schedule repeats
+        let interval = TimeInterval(config.checkInterval)
+        checkTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.checkForUpdates()
+        }
+        print("[UpdateManager] Scheduled periodic check every \(config.checkInterval)s")
+    }
+    
+    func checkForUpdates() {
+        let config = ConfigManager.shared.config.update
+        guard config.enabled else { return }
+        
+        // Don't interrupt active update flow
+        let canCheck = state == .idle || state == .checking || isFailedState
+        guard canCheck else { return }
+        
+        state = .checking
+        
+        guard let url = URL(string: "\(config.serverUrl)/api/v1/aether/latest") else {
+            state = .failed(error: "Invalid server URL: \(config.serverUrl)")
+            return
+        }
+        
+        print("[UpdateManager] Checking for updates at \(url.absoluteString)...")
+        
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map(\.data)
+            .decode(type: AetherVersionInfo.self, decoder: JSONDecoder())
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("[UpdateManager] Check failed: \(error.localizedDescription)")
+                    // Silent fail if background, but record error if we were explicitly checking
+                    self.state = .idle 
+                }
+            } receiveValue: { info in
+                self.processVersionInfo(info)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func processVersionInfo(_ info: AetherVersionInfo) {
+        guard let remoteVer = SemanticVersion(info.version),
+              let currentStr = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let currentVer = SemanticVersion(currentStr) else {
+            print("[UpdateManager] Failed to parse version strings: remote=\(info.version)")
+            state = .idle
+            return
+        }
+        
+        if remoteVer > currentVer {
+            print("[UpdateManager] New version available: \(info.version) (current: \(currentStr))")
+            self.availableVersion = info
+            self.state = .available(version: info.version)
+        } else {
+            print("[UpdateManager] Up to date (remote=\(info.version), current=\(currentStr))")
+            self.state = .idle
+        }
+    }
+    
+    // MARK: - Stubs for Phase 4/5
+    
+    func downloadUpdate() {
+        print("[UpdateManager] downloadUpdate() - Stube for Phase 4")
+    }
+    
+    func cancelDownload() {
+        print("[UpdateManager] cancelDownload() - Stube for Phase 4")
+    }
+}
+
+// Helper for switch case matching on Equatable enum with associated values
+func ==(lhs: UpdateManager.UpdateState, rhs: UpdateManager.UpdateState) -> Bool {
+    switch (lhs, rhs) {
+    case (.idle, .idle): return true
+    case (.checking, .checking): return true
+    case (.available(let v1), .available(let v2)): return v1 == v2
+    case (.downloading, .downloading): return true
+    case (.readyToInstall, .readyToInstall): return true
+    case (.installing, .installing): return true
+    case (.failed(let e1), .failed(let e2)): return e1 == e2
+    case (.restartRequired, .restartRequired): return true
+    default: return false
+    }
+}

--- a/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct UpdateBadgeView: View {
+    @ObservedObject var updateManager = UpdateManager.shared
+    @ObservedObject var configManager = ConfigManager.shared
+    
+    @State private var isAnimating = false
+    
+    var body: some View {
+        if case .available(let version) = updateManager.state {
+            Button(action: {
+                print("[UpdateBadgeView] User clicked update badge: \(version)")
+                updateManager.downloadUpdate()
+            }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 11, weight: .bold))
+                    
+                    Text("\(version) available")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule()
+                        .fill(accentColor.opacity(0.15))
+                )
+                .overlay(
+                    Capsule()
+                        .stroke(accentColor.opacity(0.4), lineWidth: 0.5)
+                )
+                .foregroundColor(accentColor)
+                .scaleEffect(isAnimating ? 1.05 : 1.0)
+            }
+            .buttonStyle(.plain)
+            .transition(.asymmetric(
+                insertion: .move(edge: .top).combined(with: .opacity),
+                removal: .opacity
+            ))
+            .onAppear {
+                withAnimation(Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    isAnimating = true
+                }
+            }
+        }
+    }
+    
+    private var accentColor: Color {
+        let theme = configManager.config.colors.resolveTheme()
+        // Index 2 is usually green/success in our themes (palette: [bg, fg, green, yellow, red, ...])
+        return Color(hex: theme.palette[2])
+    }
+}

--- a/apps/aether/AetherApp/Tests/AetherAppTests/UpdateManagerTests.swift
+++ b/apps/aether/AetherApp/Tests/AetherAppTests/UpdateManagerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import AetherApp
+
+final class UpdateManagerTests: XCTestCase {
+    
+    // MARK: - SemanticVersion Tests
+    
+    func testSemverComparison() {
+        XCTAssertTrue(SemanticVersion("1.0.0")! > SemanticVersion("0.9.9")!)
+        XCTAssertTrue(SemanticVersion("0.4.0")! > SemanticVersion("0.3.9")!)
+        XCTAssertTrue(SemanticVersion("0.3.1")! > SemanticVersion("0.3.0")!)
+        XCTAssertTrue(SemanticVersion("1.2.3")! == SemanticVersion("1.2.3")!)
+        XCTAssertFalse(SemanticVersion("1.0.0")! > SemanticVersion("1.0.0")!)
+    }
+    
+    func testSemverPrefix() {
+        XCTAssertEqual(SemanticVersion("v1.0.0"), SemanticVersion("1.0.0"))
+        XCTAssertTrue(SemanticVersion("v0.4.0")! > SemanticVersion("0.3.0")!)
+    }
+    
+    func testSemverParsing() {
+        XCTAssertNotNil(SemanticVersion("1.0"))
+        XCTAssertNotNil(SemanticVersion("1.0.0"))
+        XCTAssertNil(SemanticVersion("invalid"))
+        XCTAssertNil(SemanticVersion("1"))
+        
+        let v = SemanticVersion("1.2")!
+        XCTAssertEqual(v.major, 1)
+        XCTAssertEqual(v.minor, 2)
+        XCTAssertEqual(v.patch, 0)
+    }
+    
+    func testSemverSort() {
+        let versions = ["0.3.0", "1.0.0", "0.9.0", "v0.3.1"].compactMap { SemanticVersion($0) }
+        let sorted = versions.sorted()
+        XCTAssertEqual(sorted.last?.originalString, "1.0.0")
+        XCTAssertEqual(sorted.first?.originalString, "0.3.0")
+    }
+    
+    // MARK: - UpdateState Tests
+    
+    func testUpdateStateEquality() {
+        XCTAssertEqual(UpdateManager.UpdateState.idle, .idle)
+        XCTAssertEqual(UpdateManager.UpdateState.available(version: "1.0.0"), .available(version: "1.0.0"))
+        XCTAssertNotEqual(UpdateManager.UpdateState.available(version: "1.0.0"), .available(version: "1.0.1"))
+        XCTAssertNotEqual(UpdateManager.UpdateState.idle, .checking)
+    }
+    
+    func testUpdateStateHelpers() {
+        XCTAssertTrue(UpdateManager.UpdateState.downloading.isProgressState)
+        XCTAssertTrue(UpdateManager.UpdateState.installing.isProgressState)
+        XCTAssertFalse(UpdateManager.UpdateState.idle.isProgressState)
+        
+        XCTAssertTrue(UpdateManager.UpdateState.failed(error: "test").isFailedState)
+        XCTAssertFalse(UpdateManager.UpdateState.idle.isFailedState)
+    }
+}


### PR DESCRIPTION
### PR for Phases 2 & 3 of Aether Auto-Update System

**Changes:**
- [x] Create **UpdateManager.swift** — singleton, ObservableObject managing the update lifecycle.
- [x] Implement **SemanticVersion** struct with Comparable/Equatable for proper version comparison (ignoring 'v' prefix).
- [x] Implement **checkForUpdates()** — calls SysCore GET `/api/v1/aether/latest`.
- [x] Implement **schedulePeriodicCheck()** — respects `check_interval` from config.
- [x] Create **UpdateBadgeView.swift** — theme-aware capsule button for the title bar.
- [x] Wire into **AetherApp.swift** — title bar integration and start check on launch.

**Verification:**
- [x] **Build Successful**: `swift build` passed.
- [x] **Logic Verified**: Manually verified `SemanticVersion` and `UpdateState` logic via standalone script (since environment lacks XCTest).
- [x] **Theme Awareness**: Uses existing theme resolution patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic update checking that automatically verifies for new versions from a remote server.
  * New visual badge appears in the title bar when updates are available for download.
  * Users can click the badge to initiate the update download process.

* **Tests**
  * Comprehensive test coverage added for version comparison and update state management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->