### PR TITLE
feat: Aether update modal and installation logic (Phases 4 & 5)

### DIFF
--- a/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
@@ -141,6 +141,13 @@ struct AetherApp: App {
                     .zIndex(101)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
+                
+                // Update Modal Overlay
+                if updateManager.showModal {
+                    UpdateModalView(isPresented: $updateManager.showModal)
+                        .zIndex(102)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                }
             }
             .background(Color.clear) // Ensure window background doesn't bleed if possible
             .onAppear {

--- a/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/AetherApp.swift
@@ -6,6 +6,7 @@ import Combine
 struct AetherApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject var tabManager = TabManager()
+    @StateObject var updateManager = UpdateManager.shared
     @ObservedObject var configManager = ConfigManager.shared
     
     // First Run Experience
@@ -44,9 +45,12 @@ struct AetherApp: App {
                                         .id(session.id.uuidString + session.windowTitle) // Redraw on session/title change
                             }
                             
-                            // Custom Button Removed
+                            // Title Bar Buttons
                             HStack {
                                 Spacer()
+                                
+                                UpdateBadgeView()
+                                    .padding(.trailing, 10)
                             }
                             .frame(height: 28)
                         }
@@ -149,6 +153,9 @@ struct AetherApp: App {
                 
                 // Trigger async session loading — does NOT block main thread
                 SessionManager.shared.loadAsync()
+                
+                // Update management
+                updateManager.schedulePeriodicCheck()
             }
             .onReceive(SessionManager.shared.$isLoaded) { loaded in
                 guard loaded else { return }

--- a/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import AppKit
 
 /// Numeric semantic versioning (major.minor.patch)
 struct SemanticVersion: Comparable, CustomStringConvertible {
@@ -52,13 +53,14 @@ struct AetherVersionInfo: Codable {
     }
 }
 
-class UpdateManager: ObservableObject {
+class UpdateManager: NSObject, ObservableObject {
     static let shared = UpdateManager()
     
     @Published var state: UpdateState = .idle
     @Published var availableVersion: AetherVersionInfo?
     @Published var downloadProgress: Double = 0.0
     @Published var statusMessage: String = ""
+    @Published var showModal: Bool = false
     
     private var checkTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
@@ -87,7 +89,14 @@ class UpdateManager: ObservableObject {
     
     var isFailedState: Bool { state.isFailedState }
     
-    private init() {
+    private var downloadTask: URLSessionDownloadTask?
+    private lazy var downloadSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        return URLSession(configuration: config, delegate: self, delegateQueue: .main)
+    }()
+
+    override private init() {
+        super.init()
         // Log current version for debugging
         if let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
             print("[UpdateManager] Current version: \(currentVersion)")
@@ -138,7 +147,6 @@ class UpdateManager: ObservableObject {
             .sink { completion in
                 if case .failure(let error) = completion {
                     print("[UpdateManager] Check failed: \(error.localizedDescription)")
-                    // Silent fail if background, but record error if we were explicitly checking
                     self.state = .idle 
                 }
             } receiveValue: { info in
@@ -166,14 +174,176 @@ class UpdateManager: ObservableObject {
         }
     }
     
-    // MARK: - Stubs for Phase 4/5
+    // MARK: - Phase 4: Download
     
     func downloadUpdate() {
-        print("[UpdateManager] downloadUpdate() - Stube for Phase 4")
+        guard let info = availableVersion else { return }
+        let config = ConfigManager.shared.config.update
+        
+        guard let url = URL(string: "\(config.serverUrl)/api/v1/aether/download/bundle?v=\(info.version)") else {
+            state = .failed(error: "Invalid download URL")
+            return
+        }
+        
+        state = .downloading
+        downloadProgress = 0.0
+        
+        downloadTask = downloadSession.downloadTask(with: url)
+        downloadTask?.resume()
+        print("[UpdateManager] Started download: \(url.absoluteString)")
     }
     
     func cancelDownload() {
-        print("[UpdateManager] cancelDownload() - Stube for Phase 4")
+        downloadTask?.cancel()
+        downloadTask = nil
+        state = .idle
+        downloadProgress = 0.0
+    }
+    
+    // MARK: - Phase 5: Install
+    
+    func applyUpdate() {
+        guard let info = availableVersion else { return }
+        state = .installing
+        statusMessage = "Preparing installation..."
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.performInstallation(version: info.version)
+        }
+    }
+    
+    private func performInstallation(version: String) {
+        let fileManager = FileManager.default
+        let bundleURL = Bundle.main.bundleURL // /Applications/Aether.app
+        let contentsURL = bundleURL.appendingPathComponent("Contents")
+        
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let aetherDir = appSupport.appendingPathComponent("Aether")
+        let updatesDir = aetherDir.appendingPathComponent("updates").appendingPathComponent(version)
+        let backupDir = aetherDir.appendingPathComponent("backup")
+        let tarballPath = updatesDir.appendingPathComponent("Aether-bundle-\(version).tar.gz")
+        
+        do {
+            updateStatus("Checking permissions...")
+            // 1. Verify we can write to bundle
+            if !fileManager.isWritableFile(atPath: bundleURL.path) {
+                throw UpdateError.notWritable("Aether is not in a writable location (e.g. /Applications with SIP). Please move it to your Applications folder or a user-writable directory.")
+            }
+            
+            // 2. Backup
+            updateStatus("Creating backup...")
+            if fileManager.fileExists(atPath: backupDir.path) {
+                try fileManager.removeItem(at: backupDir)
+            }
+            try fileManager.createDirectory(at: backupDir, withIntermediateDirectories: true)
+            try fileManager.copyItem(at: contentsURL, to: backupDir.appendingPathComponent("Contents"))
+            
+            // 3. Extract
+            updateStatus("Extracting update...")
+            let tarProcess = Process()
+            tarProcess.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+            tarProcess.arguments = ["-xzf", tarballPath.path, "-C", bundleURL.path]
+            try tarProcess.run()
+            tarProcess.waitUntilExit()
+            
+            if tarProcess.terminationStatus != 0 {
+                throw UpdateError.extractionFailed("Tar extraction failed with exit code \(tarProcess.terminationStatus)")
+            }
+            
+            // 4. Re-sign (Ad-hoc)
+            updateStatus("Verifying signature...")
+            let signProcess = Process()
+            signProcess.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+            signProcess.arguments = ["--force", "--deep", "--sign", "-", bundleURL.path]
+            try signProcess.run()
+            signProcess.waitUntilExit()
+            
+            // 5. Success
+            updateStatus("Update complete!")
+            
+            // Record pending update for Phase 6 "What's New"
+            UserDefaults.standard.set(version, forKey: "pendingUpdateVersion")
+            if let changelog = availableVersion?.changelog {
+                UserDefaults.standard.set(changelog, forKey: "pendingUpdateChangelog")
+            }
+            
+            DispatchQueue.main.async {
+                self.state = .restartRequired
+            }
+            
+        } catch {
+            print("[UpdateManager] Installation failed: \(error)")
+            // Rollback
+            try? fileManager.removeItem(at: contentsURL)
+            try? fileManager.copyItem(at: backupDir.appendingPathComponent("Contents"), to: contentsURL)
+            
+            DispatchQueue.main.async {
+                self.state = .failed(error: (error as? UpdateError)?.message ?? error.localizedDescription)
+            }
+        }
+    }
+    
+    private func updateStatus(_ msg: String) {
+        DispatchQueue.main.async {
+            self.statusMessage = msg
+        }
+    }
+    
+    func restartApp() {
+        let bundleURL = Bundle.main.bundleURL
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { _, error in
+            if let error = error {
+                print("[UpdateManager] Failed to restart app: \(error)")
+            } else {
+                NSApp.terminate(nil)
+            }
+        }
+    }
+}
+
+extension UpdateManager: URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        guard let info = availableVersion else { return }
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let updatesDir = appSupport.appendingPathComponent("Aether/updates/\(info.version)")
+        let destination = updatesDir.appendingPathComponent("Aether-bundle-\(info.version).tar.gz")
+        
+        do {
+            try fileManager.createDirectory(at: updatesDir, withIntermediateDirectories: true)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.moveItem(at: location, to: destination)
+            
+            DispatchQueue.main.async {
+                self.state = .readyToInstall
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.state = .failed(error: "Failed to save update: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        DispatchQueue.main.async {
+            self.downloadProgress = progress
+        }
+    }
+}
+
+enum UpdateError: Error {
+    case notWritable(String)
+    case extractionFailed(String)
+    
+    var message: String {
+        switch self {
+        case .notWritable(let m): return m
+        case .extractionFailed(let m): return m
+        }
     }
 }
 

--- a/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Models/UpdateManager.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Combine
+
+/// Numeric semantic versioning (major.minor.patch)
+struct SemanticVersion: Comparable, CustomStringConvertible {
+    let major: Int
+    let minor: Int
+    let patch: Int
+    let originalString: String
+
+    init?(_ versionString: String) {
+        let cleaned = versionString.hasPrefix("v") ? String(versionString.dropFirst()) : versionString
+        let parts = cleaned.split(separator: ".").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        
+        // Support 1.0, 1.0.0, etc.
+        guard parts.count >= 2 else { return nil }
+        
+        self.major = parts[0]
+        self.minor = parts[1]
+        self.patch = parts.count > 2 ? parts[2] : 0
+        self.originalString = versionString
+    }
+
+    var description: String { originalString }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+
+    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
+    }
+}
+
+/// Metadata returned by GET /api/v1/aether/latest
+struct AetherVersionInfo: Codable {
+    let version: String
+    let description: String
+    let changelog: String
+    let releaseDate: String
+    let size: Int64
+    let bundleFilename: String?
+    let bundleSize: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case version, description, changelog, size
+        case releaseDate = "release_date"
+        case bundleFilename = "bundle_filename"
+        case bundleSize = "bundle_size"
+    }
+}
+
+class UpdateManager: ObservableObject {
+    static let shared = UpdateManager()
+    
+    @Published var state: UpdateState = .idle
+    @Published var availableVersion: AetherVersionInfo?
+    @Published var downloadProgress: Double = 0.0
+    @Published var statusMessage: String = ""
+    
+    private var checkTimer: Timer?
+    private var cancellables = Set<AnyCancellable>()
+    
+    enum UpdateState: Equatable {
+        case idle
+        case checking
+        case available(version: String)
+        case downloading
+        case readyToInstall
+        case installing
+        case failed(error: String)
+        case restartRequired
+        
+        var isProgressState: Bool {
+            if case .downloading = self { return true }
+            if case .installing = self { return true }
+            return false
+        }
+        
+        var isFailedState: Bool {
+            if case .failed = self { return true }
+            return false
+        }
+    }
+    
+    var isFailedState: Bool { state.isFailedState }
+    
+    private init() {
+        // Log current version for debugging
+        if let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            print("[UpdateManager] Current version: \(currentVersion)")
+        }
+    }
+    
+    func schedulePeriodicCheck() {
+        checkTimer?.invalidate()
+        
+        let config = ConfigManager.shared.config.update
+        guard config.enabled else {
+            print("[UpdateManager] Updates disabled in config.")
+            return
+        }
+        
+        // Initial check
+        checkForUpdates()
+        
+        // Schedule repeats
+        let interval = TimeInterval(config.checkInterval)
+        checkTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.checkForUpdates()
+        }
+        print("[UpdateManager] Scheduled periodic check every \(config.checkInterval)s")
+    }
+    
+    func checkForUpdates() {
+        let config = ConfigManager.shared.config.update
+        guard config.enabled else { return }
+        
+        // Don't interrupt active update flow
+        let canCheck = state == .idle || state == .checking || isFailedState
+        guard canCheck else { return }
+        
+        state = .checking
+        
+        guard let url = URL(string: "\(config.serverUrl)/api/v1/aether/latest") else {
+            state = .failed(error: "Invalid server URL: \(config.serverUrl)")
+            return
+        }
+        
+        print("[UpdateManager] Checking for updates at \(url.absoluteString)...")
+        
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map(\.data)
+            .decode(type: AetherVersionInfo.self, decoder: JSONDecoder())
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("[UpdateManager] Check failed: \(error.localizedDescription)")
+                    // Silent fail if background, but record error if we were explicitly checking
+                    self.state = .idle 
+                }
+            } receiveValue: { info in
+                self.processVersionInfo(info)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func processVersionInfo(_ info: AetherVersionInfo) {
+        guard let remoteVer = SemanticVersion(info.version),
+              let currentStr = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let currentVer = SemanticVersion(currentStr) else {
+            print("[UpdateManager] Failed to parse version strings: remote=\(info.version)")
+            state = .idle
+            return
+        }
+        
+        if remoteVer > currentVer {
+            print("[UpdateManager] New version available: \(info.version) (current: \(currentStr))")
+            self.availableVersion = info
+            self.state = .available(version: info.version)
+        } else {
+            print("[UpdateManager] Up to date (remote=\(info.version), current=\(currentStr))")
+            self.state = .idle
+        }
+    }
+    
+    // MARK: - Stubs for Phase 4/5
+    
+    func downloadUpdate() {
+        print("[UpdateManager] downloadUpdate() - Stube for Phase 4")
+    }
+    
+    func cancelDownload() {
+        print("[UpdateManager] cancelDownload() - Stube for Phase 4")
+    }
+}
+
+// Helper for switch case matching on Equatable enum with associated values
+func ==(lhs: UpdateManager.UpdateState, rhs: UpdateManager.UpdateState) -> Bool {
+    switch (lhs, rhs) {
+    case (.idle, .idle): return true
+    case (.checking, .checking): return true
+    case (.available(let v1), .available(let v2)): return v1 == v2
+    case (.downloading, .downloading): return true
+    case (.readyToInstall, .readyToInstall): return true
+    case (.installing, .installing): return true
+    case (.failed(let e1), .failed(let e2)): return e1 == e2
+    case (.restartRequired, .restartRequired): return true
+    default: return false
+    }
+}

--- a/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
@@ -10,7 +10,7 @@ struct UpdateBadgeView: View {
         if case .available(let version) = updateManager.state {
             Button(action: {
                 print("[UpdateBadgeView] User clicked update badge: \(version)")
-                updateManager.downloadUpdate()
+                updateManager.showModal = true
             }) {
                 HStack(spacing: 6) {
                     Image(systemName: "arrow.up.circle.fill")

--- a/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateBadgeView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct UpdateBadgeView: View {
+    @ObservedObject var updateManager = UpdateManager.shared
+    @ObservedObject var configManager = ConfigManager.shared
+    
+    @State private var isAnimating = false
+    
+    var body: some View {
+        if case .available(let version) = updateManager.state {
+            Button(action: {
+                print("[UpdateBadgeView] User clicked update badge: \(version)")
+                updateManager.downloadUpdate()
+            }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 11, weight: .bold))
+                    
+                    Text("\(version) available")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule()
+                        .fill(accentColor.opacity(0.15))
+                )
+                .overlay(
+                    Capsule()
+                        .stroke(accentColor.opacity(0.4), lineWidth: 0.5)
+                )
+                .foregroundColor(accentColor)
+                .scaleEffect(isAnimating ? 1.05 : 1.0)
+            }
+            .buttonStyle(.plain)
+            .transition(.asymmetric(
+                insertion: .move(edge: .top).combined(with: .opacity),
+                removal: .opacity
+            ))
+            .onAppear {
+                withAnimation(Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    isAnimating = true
+                }
+            }
+        }
+    }
+    
+    private var accentColor: Color {
+        let theme = configManager.config.colors.resolveTheme()
+        // Index 2 is usually green/success in our themes (palette: [bg, fg, green, yellow, red, ...])
+        return Color(hex: theme.palette[2])
+    }
+}

--- a/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateModalView.swift
+++ b/apps/aether/AetherApp/Sources/AetherApp/Views/UpdateModalView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+struct UpdateModalView: View {
+    @ObservedObject var updateManager = UpdateManager.shared
+    @ObservedObject var configManager = ConfigManager.shared
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        ZStack {
+            // Background Dimmer
+            Color.black.opacity(0.4)
+                .edgesIgnoringSafeArea(.all)
+                .onTapGesture {
+                    if !updateManager.state.isProgressState {
+                        isPresented = false
+                    }
+                }
+            
+            // Modal Container
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("SOFTWARE UPDATE")
+                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .foregroundColor(.secondary)
+                    
+                    Spacer()
+                    
+                    if !updateManager.state.isProgressState {
+                        Button(action: { isPresented = false }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
+                
+                Divider().opacity(0.1)
+                
+                // Content Based on State
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        contentView
+                    }
+                    .padding(20)
+                }
+                .frame(maxHeight: 400)
+                
+                Divider().opacity(0.1)
+                
+                // Footer / Actions
+                HStack(spacing: 12) {
+                    footerActions
+                }
+                .padding(20)
+            }
+            .frame(width: 480)
+            .background(
+                VisualEffectView(material: .hudWindow, blendingMode: .withinWindow)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.white.opacity(0.1), lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(0.3), radius: 20, x: 0, y: 10)
+        }
+        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+    }
+    
+    @ViewBuilder
+    private var contentView: some View {
+        if let info = updateManager.availableVersion {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Aether \(info.version)")
+                        .font(.system(size: 24, weight: .bold))
+                    
+                    Spacer()
+                    
+                    Text(info.releaseDate.prefix(10)) // Simple date extract
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+                
+                Text(info.description)
+                    .font(.system(size: 14))
+                    .foregroundColor(.primary.opacity(0.8))
+                
+                if !info.changelog.isEmpty {
+                    Text("WHAT'S NEW")
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .padding(.top, 8)
+                    
+                    Text(info.changelog)
+                        .font(.system(size: 13, design: .monospaced))
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.white.opacity(0.05))
+                        .cornerRadius(6)
+                }
+            }
+        } else if case .failed(let error) = updateManager.state {
+             VStack(alignment: .center, spacing: 12) {
+                 Image(systemName: "exclamationmark.triangle.fill")
+                     .font(.system(size: 40))
+                     .foregroundColor(.red)
+                 
+                 Text("Update Failed")
+                     .font(.headline)
+                 
+                 Text(error)
+                     .font(.subheadline)
+                     .multilineTextAlignment(.center)
+                     .foregroundColor(.secondary)
+             }
+             .frame(maxWidth: .infinity)
+        } else {
+            // General status for checking/idle?
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .padding()
+        }
+    }
+    
+    @ViewBuilder
+    private var footerActions: some View {
+        switch updateManager.state {
+        case .available:
+            Button("Skip This Version") {
+                // Future: Add to ignored versions
+                isPresented = false
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.secondary)
+            
+            Spacer()
+            
+            Button("Download and Install") {
+                updateManager.downloadUpdate()
+            }
+            .buttonStyle(ProminentButtonStyle())
+            
+        case .downloading:
+            VStack(spacing: 8) {
+                ProgressView(value: updateManager.downloadProgress)
+                    .progressViewStyle(.linear)
+                
+                HStack {
+                    Text("\(Int(updateManager.downloadProgress * 100))%")
+                        .font(.system(size: 10, design: .monospaced))
+                    Spacer()
+                    Button("Cancel") {
+                        updateManager.cancelDownload()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.red)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            
+        case .readyToInstall:
+            Button("Install Later") {
+                isPresented = false
+            }
+            .buttonStyle(.plain)
+            
+            Spacer()
+            
+            Button("Restart & Update") {
+                updateManager.applyUpdate()
+            }
+            .buttonStyle(ProminentButtonStyle())
+            
+        case .installing:
+             HStack(spacing: 12) {
+                 ProgressView()
+                     .scaleEffect(0.8)
+                 Text(updateManager.statusMessage.isEmpty ? "Installing..." : updateManager.statusMessage)
+                     .font(.system(size: 13, design: .monospaced))
+             }
+             .frame(maxWidth: .infinity)
+             
+        case .restartRequired:
+            Spacer()
+            Button("Restart Now") {
+                updateManager.restartApp()
+            }
+            .buttonStyle(ProminentButtonStyle())
+            
+        case .failed:
+            Spacer()
+            Button("Try Again") {
+                updateManager.checkForUpdates()
+            }
+            .buttonStyle(ProminentButtonStyle())
+            
+        default:
+            EmptyView()
+        }
+    }
+    
+    private var accentColor: Color {
+        let theme = configManager.config.colors.resolveTheme()
+        return Color(hex: theme.palette[2])
+    }
+}
+
+struct ProminentButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color.accentColor)
+            .foregroundColor(.white)
+            .cornerRadius(6)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+    }
+}

--- a/apps/aether/AetherApp/Tests/AetherAppTests/UpdateManagerTests.swift
+++ b/apps/aether/AetherApp/Tests/AetherAppTests/UpdateManagerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import AetherApp
+
+final class UpdateManagerTests: XCTestCase {
+    
+    // MARK: - SemanticVersion Tests
+    
+    func testSemverComparison() {
+        XCTAssertTrue(SemanticVersion("1.0.0")! > SemanticVersion("0.9.9")!)
+        XCTAssertTrue(SemanticVersion("0.4.0")! > SemanticVersion("0.3.9")!)
+        XCTAssertTrue(SemanticVersion("0.3.1")! > SemanticVersion("0.3.0")!)
+        XCTAssertTrue(SemanticVersion("1.2.3")! == SemanticVersion("1.2.3")!)
+        XCTAssertFalse(SemanticVersion("1.0.0")! > SemanticVersion("1.0.0")!)
+    }
+    
+    func testSemverPrefix() {
+        XCTAssertEqual(SemanticVersion("v1.0.0"), SemanticVersion("1.0.0"))
+        XCTAssertTrue(SemanticVersion("v0.4.0")! > SemanticVersion("0.3.0")!)
+    }
+    
+    func testSemverParsing() {
+        XCTAssertNotNil(SemanticVersion("1.0"))
+        XCTAssertNotNil(SemanticVersion("1.0.0"))
+        XCTAssertNil(SemanticVersion("invalid"))
+        XCTAssertNil(SemanticVersion("1"))
+        
+        let v = SemanticVersion("1.2")!
+        XCTAssertEqual(v.major, 1)
+        XCTAssertEqual(v.minor, 2)
+        XCTAssertEqual(v.patch, 0)
+    }
+    
+    func testSemverSort() {
+        let versions = ["0.3.0", "1.0.0", "0.9.0", "v0.3.1"].compactMap { SemanticVersion($0) }
+        let sorted = versions.sorted()
+        XCTAssertEqual(sorted.last?.originalString, "1.0.0")
+        XCTAssertEqual(sorted.first?.originalString, "0.3.0")
+    }
+    
+    // MARK: - UpdateState Tests
+    
+    func testUpdateStateEquality() {
+        XCTAssertEqual(UpdateManager.UpdateState.idle, .idle)
+        XCTAssertEqual(UpdateManager.UpdateState.available(version: "1.0.0"), .available(version: "1.0.0"))
+        XCTAssertNotEqual(UpdateManager.UpdateState.available(version: "1.0.0"), .available(version: "1.0.1"))
+        XCTAssertNotEqual(UpdateManager.UpdateState.idle, .checking)
+    }
+    
+    func testUpdateStateHelpers() {
+        XCTAssertTrue(UpdateManager.UpdateState.downloading.isProgressState)
+        XCTAssertTrue(UpdateManager.UpdateState.installing.isProgressState)
+        XCTAssertFalse(UpdateManager.UpdateState.idle.isProgressState)
+        
+        XCTAssertTrue(UpdateManager.UpdateState.failed(error: "test").isFailedState)
+        XCTAssertFalse(UpdateManager.UpdateState.idle.isFailedState)
+    }
+}


### PR DESCRIPTION
### PR for Phases 4 & 5 (Swift side) of Aether Auto-Update System

**Changes:**
- [x] Create **UpdateModalView.swift** — state-driven overlay with changelog, progress bar, and installation controls.
- [x] Implement **downloadUpdate()** — uses `URLSessionDownloadTask` with delegation for real-time progress.
- [x] Implement **applyUpdate()** — handles backup of `Contents/`, extraction of tarball update, and ad-hoc re-signing using `codesign`.
- [x] Implement **restartApp()** — re-opens the app via `NSWorkspace` and terminates the current instance.
- [x] Wire into **AetherApp.swift** — presents the modal when triggered by the title bar badge.

**Verification:**
- [x] **Build Successful**: `swift build` passed after fixing `AppKit` imports and `NSObject` inheritance.
- [x] **State Machine**: Verified UI transitions through `available` → `downloading` → `readyToInstall` → `installing` → `restartRequired` / `failed` states.