### PR TITLE
docs: Report hardcoded secret vulnerability in aether.rs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Default Fallback Secret in Aether Upload
+Vulnerability Pattern: A weak, hardcoded string ("update_me_please") is used as a fallback for the critical `AETHER_UPLOAD_KEY` environment variable in `syscore/src/server/aether.rs`.
+Systemic Cause: The developers used `unwrap_or_else` to supply a default value instead of failing securely when a critical environment variable for authentication is missing. This introduces a Broken Authentication vulnerability by falling back to a known weak key instead of denying access.
+Auditor Note: Always identify usages of `unwrap_or_else` or `unwrap_or` that supply weak default fallback secrets or credentials instead of failing securely when critical environment variables are missing.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,47 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Hardcoded Secret/Broken Auth: Weak fallback for AETHER_UPLOAD_KEY in syscore
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded fallback secret used for the API Key check.
 
+On line 315 of `syscore/src/server/aether.rs`:
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The system is designed to authenticate file uploads by checking the `Authorization: Bearer <KEY>` header against the `AETHER_UPLOAD_KEY` environment variable. However, if the `AETHER_UPLOAD_KEY` is not set in the environment, `unwrap_or_else` defaults the expected key to `"update_me_please"`.
+
+This introduces a severe security flaw: if an administrator forgets to configure `AETHER_UPLOAD_KEY`, the application fails open, allowing any attacker who knows or guesses the hardcoded default `"update_me_please"` to bypass authentication completely.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can upload arbitrary files to the Aether storage by simply passing `Authorization: Bearer update_me_please`. Since this endpoint handles critical system updates (DMG bundles, patches), a malicious actor could upload compromised binaries (e.g., trojanized updates) to the system. If users or the updater clients download these patches, it could lead to widespread malware distribution and complete system compromise for anyone updating. Combined with the previously discovered Arbitrary File Write vulnerability, this could be used for Remote Code Execution on the host server.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the `syscore` backend service *without* setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to the `/api/v1/aether` upload endpoint using a tool like `curl`:
+```bash
+curl -X POST http://localhost:3001/api/v1/aether \
+  -H "Authorization: Bearer update_me_please" \
+  -F "version=1.0.0-evil" \
+  -F "file=@/path/to/any/file.dmg" \
+  -F "description=Malicious Payload"
+```
+3. Observe that the server accepts the upload and responds with `201 Created` because the fallback authentication succeeds.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Fail securely when the environment variable is not set, rather than falling back to a default weak string.
 
-Example fix:
+1. Ideally, perform the configuration check at application startup (in `main.rs`) and refuse to boot if `AETHER_UPLOAD_KEY` is missing.
+2. At the very least, change the `upload_handler` logic to return an error if the environment variable is not present:
+
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
-
-let file_path = version_dir.join(safe_filename);
+// In syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- Hardcoded Credentials (CWE-798): https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Acts as Sentinel to report a critical vulnerability.
Identified the `unwrap_or_else` providing a weak fallback (`update_me_please`) for `AETHER_UPLOAD_KEY` in `syscore/src/server/aether.rs`.
Formatted the vulnerability report perfectly into `SECURITY_ISSUE.md` and appended the learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10699375238553063310](https://jules.google.com/task/10699375238553063310) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated security documentation to reflect revised vulnerability findings and corresponding remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->