### PR TITLE
Report CRITICAL Hardcoded Fallback Secret in Aether Upload Auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-10-27 - Hardcoded Default Fallback Secret for Aether Upload Authentication
+Vulnerability Pattern: Hardcoded Secret Fallback via `unwrap_or_else` on environment variables.
+Systemic Cause: The `upload_handler` in `syscore/src/server/aether.rs` attempts to load the `AETHER_UPLOAD_KEY` environment variable. If missing, it falls back to a weak, hardcoded default value ("update_me_please") instead of securely failing. This allows unauthorized file uploads if the environment variable is not explicitly set.
+Auditor Note: Scan for logic flaws where critical environment variables or configuration values use weak default fallback secrets or credentials instead of failing securely when they are missing. Pay attention to `unwrap_or` and `unwrap_or_else` usages for authentication configurations.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,42 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+# 🛡️ CRITICAL Broken Auth: Hardcoded Secret Fallback for Aether Uploads
 
-🚨 Severity
+## 🚨 Severity
 CRITICAL
 
-💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+## 💡 Description
+The `/api/v1/aether` upload endpoint in `syscore` contains a severe vulnerability where missing configuration falls back to a hardcoded secret.
 
+In `syscore/src/server/aether.rs`, the `upload_handler` attempts to retrieve the `AETHER_UPLOAD_KEY` environment variable for authenticating automated uploads (e.g., from CI/CD pipelines). However, if the environment variable is missing or not set, it explicitly falls back to a weak, hardcoded default value (`"update_me_please"`).
+
+**File Location:** `syscore/src/server/aether.rs`
+**Code Snippet:**
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+This logic flaw allows unauthorized users to publish arbitrary files or malicious binaries under any version identifier if the server operator forgets to configure `AETHER_UPLOAD_KEY`. Rather than failing securely (denying access), the system defaults to an insecure state.
 
-🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+## 🎯 Potential Impact
+An unauthenticated attacker could publish malicious Aether binaries or patches by exploiting this hardcoded fallback. If users are retrieving updates through these channels, it could lead to severe supply chain attacks. This completely compromises the integrity of the published software artifacts.
 
-🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+## 🛠️ Steps to Reproduce
+1. Start the `syscore` backend *without* the `AETHER_UPLOAD_KEY` environment variable set.
+2. Send a `POST /api/v1/aether` request with a multipart form payload (including `version`, `file`, etc.).
+3. Set the `Authorization` header to `Bearer update_me_please`.
+4. Observe that the server returns a `201 Created` and successfully stores the upload in the `storage/aether` directory.
 
-✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+## ✅ Recommended Remediation
+Remove the hardcoded fallback entirely. The application should fail securely if the environment variable is not present. Ideally, the `expected_key` should be checked during the startup sequence of `syscore`, failing to boot if a valid configuration is missing. Alternatively, at the very least, reject the request if the environment variable is not set.
 
-Example fix:
+Suggested fix in `syscore/src/server/aether.rs`:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
-
-let file_path = version_dir.join(safe_filename);
+    let expected_key = match std::env::var("AETHER_UPLOAD_KEY") {
+        Ok(key) if !key.is_empty() => key,
+        _ => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Upload key not configured".to_string())),
+    };
 ```
 
-🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+## 🔗 References
+* [OWASP Top 10 A07:2021 – Identification and Authentication Failures](https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/)
+* [OWASP Top 10 A05:2021 – Security Misconfiguration](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/)
+* [CWE-798: Use of Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)


### PR DESCRIPTION
I have identified a CRITICAL Broken Auth vulnerability in `syscore/src/server/aether.rs` where missing configuration falls back to the hardcoded secret "update_me_please". This allows unauthenticated users to upload malicious Aether binaries.

I have updated the `.jules/sentinel.md` journal with this pattern and created a detailed GitHub Issue in `SECURITY_ISSUE.md` adhering to the required emoji template. No source files were modified, and no new tests were required for this audit documentation. All existing `syscore` tests pass.

---
*PR created automatically by Jules for task [10638457665543692943](https://jules.google.com/task/10638457665543692943) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated security documentation to clarify an authentication vulnerability affecting the file upload endpoint. A weak fallback authentication mechanism documented in the system could allow unauthorized file uploads when environment configuration is incomplete. Users should ensure proper authentication configuration and take precautions to prevent unauthorized access to upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->