### PR TITLE
Security Audit: Unbounded Wait DoS Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2026-03-25 - Unbounded Wait leading to Denial of Service in Container Execution
+Vulnerability Pattern: Unbounded Wait / Resource Exhaustion via missing timeout on user code execution.
+Systemic Cause: User-submitted code is executed inside a Docker container, but the `.await` on the container's exit future `self.docker.wait_container::<String>(&id, None).next().await` lacks a timeout wrapper. This allows infinite loops in user code to run indefinitely, tying up system and Docker resources.
+Auditor Note: Always verify that untrusted processes or remote invocations enforce strict timeouts (e.g., using `tokio::time::timeout`) when yielding or waiting to avoid resource exhaustion and Denial of Service (DoS) attacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,57 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ [CRITICAL] [Denial of Service]: Unbounded wait in docker container execution leads to DoS
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+In `syscore/src/docker/manager.rs`, the `execute` method spawns an ephemeral Docker container to run user-submitted code (via Python or C++). However, on line 227:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The system waits indefinitely for the container to finish execution. There is no timeout enforced around this `.await` call. If a user submits malicious code containing an infinite loop (e.g., `while True: pass` in Python), the container will run forever. Because `host_config` restricts network and memory but does NOT restrict execution time, the async task inside `execute_handler` will hang indefinitely.
+
+Over time, an attacker can submit multiple requests with infinite loops, exhausting server resources (memory, CPU, and available Docker tasks/threads), leading to a complete Denial of Service (DoS) for the entire application.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker can completely halt the code execution service and crash or severely degrade the backend server by continuously submitting code with infinite loops, exhausting underlying system and Docker resources.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Navigate to the code execution endpoint (e.g., `/api/execute`).
+2. Input the following Python payload:
+   ```python
+   while True:
+       pass
+   ```
+3. Observe that the request never returns, and the Docker container running the code remains active indefinitely, tying up system resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement a strict execution timeout using `tokio::time::timeout` around the `wait_container` call. If the execution exceeds the allowed time (e.g., 5 seconds), forcefully kill and remove the container.
 
-Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+// ...
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+match timeout(Duration::from_secs(5), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out. Force killing container.", job_id);
+        // Clean up immediately
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP DoS (Denial of Service): https://owasp.org/www-community/attacks/Denial_of_Service
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
As the high-precision security auditor Sentinel, I have identified a CRITICAL severity vulnerability in the code execution logic.

**Vulnerability:** Denial of Service (DoS) via Unbounded Wait in Container Execution.

**Details:**
In `syscore/src/docker/manager.rs`, the `wait_container` call on the ephemeral Docker container executing user code (Python/C++) lacks a timeout. A malicious user can submit code with an infinite loop (e.g., `while True: pass`), causing the backend async task and the container to hang indefinitely. This exhausts system resources, leading to a DoS.

**Actions Taken:**
1. Documented the full vulnerability, including steps to reproduce and recommended remediation (using `tokio::time::timeout`), in the new file `SECURITY_ISSUE.md` per the requested template.
2. Appended the architectural learning and auditor notes to the `.jules/sentinel.md` journal.
3. Adhered to strict boundaries: no actual code changes were made to the vulnerable application logic.

---
*PR created automatically by Jules for task [8964869190264595881](https://jules.google.com/task/8964869190264595881) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to identify a resource exhaustion vulnerability related to unbounded container execution waits
  * Added recommended mitigation guidance for timeout enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->