### PR TITLE
docs: report DoS vulnerability in container execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-20 - Unbounded Wait in Container Execution
+Vulnerability Pattern: Denial of Service (DoS) via missing timeout enforcement.
+Systemic Cause: The `ContainerManager::execute` method in `syscore/src/docker/manager.rs` spawns an ephemeral Docker container and waits for its exit via `docker.wait_container`. Because the wait is unbounded (i.e., no use of `tokio::time::timeout`), untrusted payloads like infinite loops will never exit and hang the backend connection indefinitely while consuming server resources.
+Auditor Note: Always ensure that blocking or waiting operations (such as waiting on network operations, external processes, or Docker containers) on untrusted inputs or tasks enforce explicit timeouts. Look for calls like `wait`, `wait_container`, or long-running stream collections without wrappers like `tokio::time::timeout`.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,61 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service: Unbounded container execution in /api/execute
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `ContainerManager::execute` function in `syscore/src/docker/manager.rs` orchestrates untrusted code execution submitted via the `/api/execute` endpoint. Currently, it waits for the Docker container to exit using `self.docker.wait_container::<String>(&id, None).next().await;` without any explicit timeout.
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because there is no timeout enforcement on the `wait_container` call, a malicious user can submit code containing an infinite loop (e.g., `while True: pass` in Python or `while(1) {}` in C++). This will cause the container to run indefinitely, consuming the allocated CPU and memory resources (256MB RAM, 1 CPU). Multiple such requests will exhaust server resources, leading to a complete Denial of Service (DoS) for the OKernel platform.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can submit multiple payloads with infinite loops to the `/api/execute` endpoint. Since each payload spins up a container that never exits and holds resources indefinitely, the server's CPU, memory, and concurrent task limits will quickly be exhausted, rendering the OKernel backend unresponsive to legitimate users.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send a POST request to the `/api/execute` endpoint with an infinite loop payload:
+   ```json
+   {
+       "language": "python",
+       "code": "while True:\n    pass"
+   }
+   ```
+3. Observe that the API request hangs indefinitely and never returns.
+4. Check the Docker daemon (`docker ps`); the spawned container (`okernel-job-<uuid>`) will be running and consuming CPU.
+5. Send multiple such requests to completely exhaust server resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Enforce a strict timeout on the container execution wait using `tokio::time::timeout`. If the timeout expires, the system should forcefully kill/remove the container and return an error to the user indicating a timeout occurred.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+
+match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(Some(Err(e))) => {
+        tracing::warn!("[Job {}] Container wait error: {}", job_id, e);
+    }
+    Ok(None) => {
+        tracing::warn!("[Job {}] Wait stream ended unexpectedly", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out! Force killing container.", job_id);
+        // Container removal logic already runs in cleanup, but ensure it force-kills
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html
+- Rust `tokio::time::timeout` documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
Reported a DoS vulnerability caused by missing timeouts during Docker container execution for untrusted code payloads. Updated SECURITY_ISSUE.md with the detailed GitHub issue template and added an entry to the Sentinel journal.

---
*PR created automatically by Jules for task [3039513265196141342](https://jules.google.com/task/3039513265196141342) started by @Vaiditya2207*