### PR TITLE
docs(security): report unbounded container execution DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Container Execution DoS
+Vulnerability Pattern: Missing timeout in async wait operation (`self.docker.wait_container::<String>(&id, None).next().await`).
+Systemic Cause: The execution engine trusts that user-submitted code (Python/C++) will eventually terminate. By omitting a strict timeout on the container execution wait block, malicious payloads (e.g., `while True: pass`) can run indefinitely, consuming server resources and blocking threads.
+Auditor Note: When auditing execution pipelines or orchestrators dealing with untrusted code, always verify the presence of explicit timeouts (e.g., `tokio::time::timeout`) wrapping container waits or process outputs.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,61 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded Container Execution via Missing Timeout
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` orchestrates the running of untrusted user-submitted code (Python/C++) inside Docker containers. However, the wait condition for the container to exit lacks any timeout enforcement:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because an attacker can submit code containing infinite loops (e.g., `while True: pass` in Python), the container will never exit. The Rust backend will `.await` indefinitely on this future. Over time, an attacker can submit multiple such requests, accumulating running containers and exhausting the server's CPU, memory, and async thread pool resources, leading to a complete Denial of Service (DoS) for the execution API.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated or authenticated attacker can submit malicious code snippets that cause infinite loops, resulting in bounded threads/async workers and server resources being permanently consumed. This will quickly bring down the `syscore` backend service and prevent legitimate users from executing code.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a JSON POST request to the `/api/execute` endpoint (or via the frontend).
+3. Provide the following payload:
+```json
+{
+  "language": "python",
+  "code": "while True:\n    pass\n"
+}
+```
+4. Send the request. Observe that the request never returns a response.
+5. Repeat step 4 multiple times.
+6. Observe via `docker ps` or server resource monitoring that the CPU is maxed out and containers are accumulating indefinitely. The application will eventually become unresponsive to new requests.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout for the container wait operation using `tokio::time::timeout`. If the container does not exit within an acceptable timeframe (e.g., 5-10 seconds), kill the container and return an error response to the user.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+
+match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out. Killing container.", job_id);
+        // Implement logic to forcefully kill the container here
+        let _ = self.docker.kill_container(&id, None).await;
+        return Err("Execution timed out".to_string());
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP DoS (Denial of Service): https://owasp.org/www-community/attacks/Denial_of_Service
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
Reported a CRITICAL Denial of Service vulnerability in syscore/src/docker/manager.rs due to the absence of a timeout in the container wait mechanism.
Appended the vulnerability finding in `.jules/sentinel.md` and detailed the attack vector, impact, and remediation in `SECURITY_ISSUE.md`.

---
*PR created automatically by Jules for task [330292300120398243](https://jules.google.com/task/330292300120398243) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated critical security issue documentation to address a denial-of-service vulnerability where container execution operations may run indefinitely without explicit timeout constraints, risking resource exhaustion, service degradation, and accumulation of stalled container processes.
  * Documented new security vulnerability regarding unbounded async container execution in backend operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->