### PR TITLE
docs: Security report on DoS via unbounded execution in docker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-18 - Missing Timeout in Container Execution
+Vulnerability Pattern: Unbounded Wait/Resource Exhaustion (Denial of Service).
+Systemic Cause: The `/api/execute` endpoint orchestrates untrusted code execution via Docker containers but fails to enforce a maximum execution duration (timeout) on `docker.wait_container`. Because user-submitted code can loop indefinitely, the server resources (CPU, memory limits, and container instance slots) can be permanently exhausted.
+Auditor Note: Always check for explicit timeouts (e.g., `tokio::time::timeout`) when interacting with external processes or Docker containers running untrusted user payloads.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,54 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service (DoS): Unbounded Execution of Untrusted Code in Docker Containers
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` is responsible for running untrusted user-submitted code in ephemeral Docker containers via the `/api/execute` endpoint. However, the execution flow waits indefinitely for the container to finish without enforcing a timeout.
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because there is no timeout mechanism (such as `tokio::time::timeout`), an attacker can submit code containing an infinite loop (e.g., `while True: pass` in Python). The container will run indefinitely, and the backend service will permanently block the async task waiting for it to complete.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can continuously submit payloads containing infinite loops to the `/api/execute` endpoint. While each container is limited to 256MB of RAM and 1 CPU, an attacker can quickly exhaust the server's CPU, memory, Docker connection pool, or process limits, leading to a complete Denial of Service (DoS) for the entire application. Legitimate users will be unable to execute code.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send a POST request to the `/api/v1/execute` endpoint with a payload containing an infinite loop:
+   ```json
+   {
+       "language": "python",
+       "code": "while True: pass"
+   }
+   ```
+3. Observe that the HTTP request never receives a response (until the client times out) and the container remains running indefinitely on the host.
+4. Send multiple such requests to exhaust server resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `docker.wait_container` operation in a timeout (e.g., `tokio::time::timeout`). If the execution exceeds the maximum allowed time (e.g., 5 seconds), the container should be forcefully stopped/killed, and an error should be returned to the client.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+// 6. Wait for execution to finish with a 5-second timeout
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(5), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out!", job_id);
+        // Clean up the running container
+        let _ = self.docker.stop_container(&id, None).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP DoS Vulnerabilities: https://owasp.org/www-community/attacks/Denial_of_Service
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
Added a CRITICAL security issue report documenting the DoS vulnerability caused by unbounded container execution due to the lack of timeout in `docker.wait_container`. Also updated the `.jules/sentinel.md` journal with this critical learning.

---
*PR created automatically by Jules for task [8653362604891438868](https://jules.google.com/task/8653362604891438868) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security issue documentation to address denial-of-service risks in code execution workflows, including impact assessment and remediation guidance
  * Added audit notes recommending explicit timeout enforcement for external process interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->