### PR TITLE
docs: add security report for missing docker wait timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-03-30 - Missing Timeout in Docker Execution Orchestration
+Vulnerability Pattern: Denial of Service (DoS) via resource exhaustion due to unbounded wait operations.
+Systemic Cause: The Docker manager implementation in `syscore/src/docker/manager.rs` does not enforce a maximum execution time limit (timeout) when waiting for user-provided untrusted code execution containers to complete via `self.docker.wait_container`.
+Auditor Note: Always verify that long-running async operations, especially those orchestrating untrusted inputs or external processes (e.g., waiting for containers), are wrapped with explicit timeouts like `tokio::time::timeout` to prevent indefinite hangs and resource exhaustion.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,49 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ [CRITICAL] [Denial of Service]: Missing Timeout in Docker Container Wait Allows Resource Exhaustion
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
-
+The `syscore/src/docker/manager.rs` module contains a critical Denial of Service (DoS) vulnerability. Within the `execute` function, the `ContainerManager` runs untrusted user code in a newly created Docker container. On line 227:
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The execution relies on `.next().await` to indefinitely wait for the container to finish. Since the container execution limits specify memory and CPU limits but do not enforce a maximum execution time limit (timeout), an attacker could submit malicious code containing an infinite loop. This would cause the container to run forever, exhausting server resources over time, and keeping the asynchronous task running indefinitely.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker can perform a Denial of Service (DoS) attack. By repeatedly sending requests with infinite loops (e.g., `while True: pass` in Python), the attacker can exhaust the server's CPU, memory, and concurrency limits (as each execution spawns an indefinite async task). This will eventually cause the backend system to become unresponsive to legitimate user requests.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Navigate to the code execution endpoint `/api/execute` (if publicly accessible or authenticated).
+2. Input the following payload as Python code:
+   ```python
+   while True:
+       pass
+   ```
+3. Observe the result: The API request hangs indefinitely and the backend task does not complete, tying up system resources. Over time, sending multiple such requests will degrade system performance or cause a crash.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
-
-Example fix:
+Wrap the `wait_container` call with `tokio::time::timeout` to enforce a strict maximum execution time for the user's code. For example:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = timeout(Duration::from_secs(10), wait_future).await;
+
+match wait_res {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out after 10 seconds", job_id);
+        // Ensure cleanup_container logic follows
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Top 10 - A04:2021-Insecure Design (Resource Exhaustion)
+- https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
Added `SECURITY_ISSUE.md` documenting a DoS vulnerability caused by missing timeouts in `syscore/src/docker/manager.rs`, and updated `.jules/sentinel.md` with architectural learnings. No code was modified in accordance with the task constraints.

---
*PR created automatically by Jules for task [3863480514175801755](https://jules.google.com/task/3863480514175801755) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit documentation to reflect current threat assessment and remediation guidelines.
  * Enhanced sentinel entries with additional auditor checklist requirements for infrastructure security.

* **Chores**
  * Improved documentation formatting and consistency across audit files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->