### PR TITLE
🛡️ CRITICAL Resource Exhaustion (DoS): Missing timeout in container execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2026-04-02 - Missing Timeout in Container Execution (DoS)
+Vulnerability Pattern: Unbounded wait on a container executing user-supplied code via `docker.wait_container`.
+Systemic Cause: The execution engine trusts that user code will eventually terminate. By failing to wrap `docker.wait_container` in a strict timeout (e.g., `tokio::time::timeout`), malicious code (like infinite loops) can run indefinitely and exhaust server resources.
+Auditor Note: Always ensure that any external process or container spawned to execute untrusted input is bound by a strict, non-bypassable timeout to prevent Resource Exhaustion and Denial of Service.
+
 ## 2024-05-18 - PathBuf::join Overwrite in Aether File Upload
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,60 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Resource Exhaustion (DoS): Missing timeout in container execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` suffers from a Denial of Service (DoS) vulnerability due to an unbounded wait for container execution. When processing untrusted user code via the `/api/execute` endpoint, the system uses `self.docker.wait_container` without any timeout:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because there is no timeout enforcement, an attacker can submit code containing an infinite loop (e.g., `while True: pass` in Python). The backend will spawn a container and indefinitely `await` its completion. By submitting multiple such requests, an attacker can exhaust all available CPU and memory resources on the host running the `syscore` service, leading to a complete system outage and rendering the service unavailable for legitimate users.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can exhaust server resources (CPU, Memory, and Docker concurrent container limits) by submitting malicious scripts that never terminate. This will cause a complete Denial of Service (DoS) for the `/api/execute` endpoint and potentially crash the entire `syscore` backend.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a POST request to the `/api/execute` endpoint with a payload containing an infinite loop in Python:
+   ```json
+   {
+       "language": "python",
+       "code": "while True: pass"
+   }
+   ```
+3. Send multiple concurrent requests using this payload.
+4. Observe that the requests never complete and the backend's resource usage (CPU/Memory) steadily increases, eventually leading to unresponsiveness or a crash.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `self.docker.wait_container` future in a strict timeout using `tokio::time::timeout`. If the execution exceeds the allowed threshold (e.g., 5 seconds), the system should forcibly kill the container and return an error to the user indicating a timeout.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(5), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+        Some(Ok(res))
+    },
+    Ok(Some(Err(e))) => {
+        tracing::warn!("[Job {}] Container wait error: {}", job_id, e);
+        Some(Err(e))
+    },
+    Ok(None) => None,
+    Err(_) => {
+        tracing::warn!("[Job {}] Container execution timed out!", job_id);
+        // Ensure cleanup_container handles stopping/killing if it's still running
+        let _ = self.docker.stop_container(&id, None).await;
+        None // Or return an explicit error to the caller
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Denial of Service: https://owasp.org/www-community/attacks/Denial_of_Service
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
Sentinel security audit report detailing an unbounded wait (Denial of Service) vulnerability in `syscore/src/docker/manager.rs` via `docker.wait_container`. Recorded in `.jules/sentinel.md` and `SECURITY_ISSUE.md` per instructions.

---
*PR created automatically by Jules for task [17597091276884139900](https://jules.google.com/task/17597091276884139900) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated security documentation to reflect a denial-of-service vulnerability in the code execution endpoint that could result in resource exhaustion and temporary service unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->