### PR TITLE
docs: Sentinel Security Report - Unbounded Wait DoS in Docker Execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Wait in Docker Execution
+Vulnerability Pattern: Denial of Service (DoS) via unbounded wait (`docker.wait_container`) without a timeout.
+Systemic Cause: The execution engine spawns ephemeral Docker containers to run untrusted, arbitrary code but relies on the container itself to exit naturally. There is no timeout enforced on the async wait operation, allowing infinite loops in user code to hold execution resources indefinitely.
+Auditor Note: Always ensure that operations executing untrusted code or external processes (especially Docker or OS-level commands) are wrapped with explicit timeouts (e.g., `tokio::time::timeout`) to prevent resource exhaustion and Denial of Service.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,54 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded Wait in Docker Container Execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+In `syscore/src/docker/manager.rs`, the `execute` method spawns an ephemeral Docker container to run unauthenticated, user-submitted code. However, it waits for the container to exit using `self.docker.wait_container::<String>(&id, None).next().await;` on line 227 without enforcing any timeout.
 
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because the `/api/execute` endpoint accepts arbitrary code (e.g., Python or C++) from the frontend without authentication, an attacker can submit code containing an infinite loop (e.g., `while True: pass`). The backend will spawn the container and `await` its completion indefinitely.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker can easily exhaust the server's compute resources by sending multiple requests with infinite loops. Each request will lock up an execution task and leave a running container consuming memory and CPU until the server hits its limits (Denial of Service). Even though memory is capped at 256MB per container, a moderate number of concurrent malicious executions will deplete system resources entirely, taking the application offline.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the backend service.
+2. Send a POST request to `/api/execute` with the payload:
+   ```json
+   {
+     "language": "python",
+     "code": "while True:\n    pass"
+   }
+   ```
+3. Observe that the request never returns, and the Docker container runs indefinitely, consuming 100% of its allotted CPU limit.
+4. Repeat this multiple times to exhaust server resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `wait_container` operation in a timeout using `tokio::time::timeout`. If the execution exceeds a reasonable timeframe (e.g., 5-10 seconds), kill the container and return an error to the user indicating a timeout.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = timeout(Duration::from_secs(10), wait_future).await;
+
+match wait_res {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out, killing container...", job_id);
+        // Ensure container is stopped/killed
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- OWASP Denial of Service: https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
This PR submits the Sentinel security audit report.

**Findings:**
A CRITICAL Denial of Service (DoS) vulnerability was discovered in `syscore/src/docker/manager.rs`. The `/api/execute` endpoint accepts arbitrary, unauthenticated code submissions and spawns an ephemeral Docker container. The backend then waits on this container using `docker.wait_container().next().await` without any enforced timeout. An attacker can submit code containing an infinite loop, causing the backend task and the running Docker container to consume resources indefinitely. Repeated requests will eventually exhaust the server's CPU and memory, taking the service offline.

**Actions Taken:**
1. Documented the vulnerability in `SECURITY_ISSUE.md` using the precise Sentinel template, including steps to reproduce and a suggested mitigation (wrapping the wait in `tokio::time::timeout`).
2. Recorded the architectural flaw in `.jules/sentinel.md`.
3. Adhered to the boundaries: no code was modified, no secrets were committed, and the vulnerability was manually verified in the source code.
4. Ran `cargo test` in `syscore/` to ensure no regressions. All tests passed.

---
*PR created automatically by Jules for task [2419561272343286982](https://jules.google.com/task/2419561272343286982) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to address a Denial of Service vulnerability in Docker container execution handling.
  * Added remediation guidance on implementing timeout controls for container operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->