### PR TITLE
docs(security): report missing timeout DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-19 - Unbounded Container Wait Exhaustion DoS
+Vulnerability Pattern: Missing Timeout in `docker.wait_container` leading to Denial of Service.
+Systemic Cause: The execution logic in `syscore/src/docker/manager.rs` does not impose any execution time limits on containers running user-submitted code via the unauthenticated `/api/execute` endpoint. Malicious code (e.g., infinite loops) will cause the Rust server thread to block indefinitely waiting for the container, exhausting server resources.
+Auditor Note: When orchestrating untrusted code or container runs, always verify the presence of explicit timeouts (e.g., `tokio::time::timeout`) to prevent unbounded wait operations and resource exhaustion vulnerabilities.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,52 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Logic Flaw: Missing Execution Timeout Allows Denial of Service via Infinite Loops
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The unauthenticated `/api/execute` endpoint invokes containerized execution of user code via `ContainerManager::execute` in `syscore/src/docker/manager.rs`. However, there is a missing timeout on the execution of the user's code.
 
+In `syscore/src/docker/manager.rs`, around line 170:
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        // 6. Wait for execution to finish
+        let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The system uses `self.docker.wait_container(...).next().await;` which waits indefinitely for the container to finish. Because untrusted user code runs inside these containers (e.g., Python/C++ code), an attacker can supply code with an infinite loop. This forces the server thread to block indefinitely, consuming server resources (e.g. Docker container instances, memory, CPU, and tokio tasks) until the host crashes or becomes unresponsive.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can submit multiple execution requests with infinite loops, exhausting system resources (Docker containers, available CPU/memory limits) and causing a complete Denial of Service (DoS) for the entire application.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the backend service.
+2. Send a POST request to `/api/execute` with malicious Python code that loops forever:
+   ```json
+   {
+       "lang": "Python",
+       "code": "while True: pass"
+   }
+   ```
+3. Observe that the server hangs waiting for the container to exit, and the container runs indefinitely.
+4. Sending multiple such requests will exhaust server resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout for container execution using `tokio::time::timeout`.
 
-Example fix:
+Example:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+        // 6. Wait for execution to finish with a strict timeout (e.g., 5 seconds)
+        let timeout_duration = std::time::Duration::from_secs(5);
+        let wait_future = self.docker.wait_container::<String>(&id, None).next();
 
-let file_path = version_dir.join(safe_filename);
+        let wait_res = match tokio::time::timeout(timeout_duration, wait_future).await {
+            Ok(res) => res,
+            Err(_) => {
+                tracing::warn!("[Job {}] Container execution timed out. Forcing termination.", job_id);
+                // Optionally kill the container here
+                None
+            }
+        };
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- [OWASP Top 10: Vulnerable and Outdated Components (CWE-400: Uncontrolled Resource Consumption)](https://cwe.mitre.org/data/definitions/400.html)


### PR DESCRIPTION
As Sentinel, investigated the codebase and found a missing execution timeout in `docker.wait_container` in `syscore/src/docker/manager.rs`, which leads to a critical Denial of Service vulnerability via resource exhaustion.
Recorded the architectural learning in `.jules/sentinel.md` and detailed the vulnerability in `SECURITY_ISSUE.md` without modifying any code.

---
*PR created automatically by Jules for task [14968262470609123478](https://jules.google.com/task/14968262470609123478) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Security**
  * Identified and documented a denial-of-service vulnerability caused by missing execution timeouts in container operations, which could result in indefinite blocking and resource exhaustion.
  * Updated security documentation with remediation guidance to address the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->