### PR TITLE
Report DoS vulnerability in Docker execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-19 - Unbounded Wait (DoS) in Docker Execution
+Vulnerability Pattern: Denial of Service (DoS) via unbounded wait during untrusted code execution.
+Systemic Cause: The `ContainerManager::execute` function calls `docker.wait_container` without a timeout wrapper. This allows malicious user-submitted code containing infinite loops to run indefinitely and exhaust server resources.
+Auditor Note: Always ensure explicit timeouts (e.g., `tokio::time::timeout`) are used when orchestrating untrusted code or container runs to prevent unbounded execution and resource exhaustion.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,59 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded wait on untrusted Docker execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `ContainerManager::execute` function in `syscore/src/docker/manager.rs` does not enforce a timeout when waiting for the Docker container to finish execution. Specifically, it calls:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because user-submitted code can contain infinite loops (e.g., `while True: pass` in Python), the container will never exit on its own. As a result, the `syscore` backend will wait indefinitely, consuming resources for the container (CPU, memory, process entries) and occupying connection streams. An attacker can repeatedly submit infinite loop scripts, leading to complete resource exhaustion and Denial of Service.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can submit multiple payloads with infinite loops to the `/api/execute` endpoint. This will cause the backend to spawn containers that never terminate. Eventually, the host will run out of system resources (memory, PIDs), bringing down the entire `syscore` backend and any co-hosted services.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send a POST request to the `/api/execute` endpoint containing an infinite loop payload. For example, for Python:
+   ```json
+   {
+       "lang": "Python",
+       "code": "while True:\n    pass"
+   }
+   ```
+3. Observe that the request never returns a response.
+4. Check the host's running Docker containers (`docker ps`). Observe that the `okernel-job-<uuid>` container is running indefinitely.
+5. Repeat the request multiple times to observe resource consumption growing without bounds until the service becomes unresponsive.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout when waiting for the container to finish. If the container does not exit within the designated timeout (e.g., 5-10 seconds), forcefully kill and remove the container, and return an error to the user indicating a timeout.
 
-Example fix:
+Example using `tokio::time::timeout`:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Container execution timed out", job_id);
+        // Clean up the container
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
+
+if let Some(Ok(res)) = wait_res {
+    tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+} else {
+    tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- OWASP Resource Exhaustion (DoS): https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
Reported a Denial of Service (DoS) vulnerability caused by unbounded wait in `ContainerManager::execute` where an attacker could exhaust server resources by submitting an infinite loop.

---
*PR created automatically by Jules for task [7806077256144963061](https://jules.google.com/task/7806077256144963061) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated security vulnerability documentation and mitigation guidelines to address denial-of-service scenarios during resource-intensive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->