### PR TITLE
🛡️ CRITICAL DoS: Unbounded wait on untrusted execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-18 - Unbounded Docker Wait Container in Code Execution
+Vulnerability Pattern: Denial of Service (DoS) via unbounded wait without a timeout on untrusted execution (`docker.wait_container`).
+Systemic Cause: The server waits indefinitely for a user-submitted script to complete its execution inside a Docker container without utilizing `tokio::time::timeout`. Malicious code containing infinite loops can thus block resources and eventually exhaust concurrent execution threads or memory.
+Auditor Note: Always verify that any function orchestrating untrusted code or container runs (e.g., `docker.wait_container`, `Command::wait`, etc.) is wrapped in an explicit timeout to prevent unbounded waits.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,50 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded wait on untrusted execution in `/api/execute`
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `/api/execute` endpoint orchestrates the execution of user-submitted code inside isolated Docker containers. In `syscore/src/docker/manager.rs`, the execution loop awaits `self.docker.wait_container::<String>(&id, None).next().await` to wait for the container to exit. However, this asynchronous operation does not employ any timeout mechanism (like `tokio::time::timeout`). Because this endpoint accepts untrusted user code without authentication or restriction, a malicious user can submit code containing an infinite loop. The container will run indefinitely, and the Rust async task will be permanently blocked awaiting the container's exit. A small number of concurrent requests executing infinite loops can exhaust server resources and open network connections, leading to a Denial of Service (DoS).
 
+References:
+- File: `syscore/src/docker/manager.rs`
+- Relevant line context:
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        // 6. Wait for execution to finish
+        let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
-
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker could cause a Denial of Service (DoS) by submitting multiple execution requests with code containing infinite loops, permanently consuming connection slots and memory as the server waits indefinitely for the containers to exit. The service would eventually become unresponsive to legitimate requests.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the server and ensure the `/api/execute` endpoint is reachable.
+2. Submit a request to the endpoint to execute a Python program containing `while True: pass`:
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"language":"python", "code":"while True: pass"}' http://localhost:8080/api/execute
+```
+3. Observe that the request never returns, and the backend server keeps running the container indefinitely.
+4. Issue multiple similar requests to quickly exhaust the server's concurrent task capacity.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `docker.wait_container` await call in a `tokio::time::timeout` to enforce a maximum execution duration (e.g., 10-30 seconds). If the timeout triggers, forcefully kill the container and return a timeout error to the user to prevent resource exhaustion.
 
-Example fix:
+Example:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(15), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        // Handle timeout: kill container and return error
+        let _ = self.docker.stop_container(&id, None).await;
+        // Optionally collect logs or just return an error
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- CWE-400: Uncontrolled Resource Consumption (https://cwe.mitre.org/data/definitions/400.html)
+- Tokio Timeout Documentation (https://docs.rs/tokio/latest/tokio/time/fn.timeout.html)


### PR DESCRIPTION
I have documented a CRITICAL Denial of Service (DoS) vulnerability in the untrusted code execution engine, specifically in `syscore/src/docker/manager.rs`.

The `/api/execute` endpoint awaits the completion of Docker containers via `docker.wait_container` but does not enforce any timeouts (e.g., using `tokio::time::timeout`). Consequently, submitting code with an infinite loop permanently blocks the executing task and exhausts concurrent resources.

**Actions taken:**
1. Created `SECURITY_ISSUE.md` documenting the vulnerability (Title, Severity, Description, Potential Impact, Steps to Reproduce, Recommended Remediation, and References).
2. Appended the systemic architectural cause to the `.jules/sentinel.md` journal.
3. Verified the codebase state through Rust tests (`cargo test` in `syscore`).
4. Maintained auditor read-only boundaries (zero codebase modifications).

---
*PR created automatically by Jules for task [2637676008374465527](https://jules.google.com/task/2637676008374465527) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with audit notes and remediation guidance for identified vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->