### PR TITLE
Report Critical DoS Vulnerability in Container Execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-18 - Missing Timeout in Container Execution (DoS)
+Vulnerability Pattern: Unbounded wait on external resource execution (`docker.wait_container`) leading to Denial of Service.
+Systemic Cause: The `/api/execute` endpoint orchestrates untrusted code execution using bespoke Docker containers. However, the wait loop on container exit does not impose a maximum timeout. Since malicious code (e.g., an infinite loop) could run forever, it can permanently tie up worker threads and exhaust server resources.
+Auditor Note: Always verify that interactions with untrusted code execution or third-party containers utilize explicit timeouts (e.g., `tokio::time::timeout`) to prevent unbounded waiting and resource exhaustion.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,58 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service: Unbounded Wait in Container Execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `ContainerManager::execute` function in `syscore/src/docker/manager.rs` suffers from a Denial of Service (DoS) vulnerability due to an unbounded wait for code execution.
+
+When user code is submitted via the `/api/execute` endpoint, the system creates a Docker container and starts it. It then waits for the container to finish using `docker.wait_container`.
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because `wait_container` has no timeout, an attacker can submit code containing an infinite loop (e.g., `while True: pass` in Python). The container will run indefinitely, and the worker thread handling the request will be permanently blocked awaiting completion. Repeated requests will rapidly exhaust the application's available worker threads, memory, and CPU resources, causing the backend service to become unresponsive to all users.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can bring down the entire `syscore` backend service by submitting a few payloads designed to run endlessly. This leads to complete service unavailability (Denial of Service).
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send an execution request to the `/api/execute` endpoint containing an infinite loop:
+   ```json
+   POST /api/execute
+   Content-Type: application/json
+
+   {
+     "language": "python",
+     "code": "while True: pass"
+   }
+   ```
+3. Observe that the request never returns a response.
+4. Send multiple similar requests concurrently.
+5. Observe that the backend becomes unresponsive and container instances are left running indefinitely, consuming server resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Introduce an explicit timeout when waiting for the container to exit. Use `tokio::time::timeout` around the `wait_container` call to enforce a maximum execution duration (e.g., 5-10 seconds). If the timeout is reached, proactively kill or stop the container and return an appropriate "Execution Timeout" error to the user.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(5), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out", job_id);
+        // Ensure cleanup removes the stuck container (e.g., using force: true)
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Denial of Service: https://owasp.org/www-community/attacks/Denial_of_Service
+- Rust Tokio Timeouts: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
This commit adds a detailed security report outlining a Denial of Service vulnerability in the `/api/execute` endpoint caused by an unbounded wait on Docker containers. The journal `.jules/sentinel.md` was also updated.

---
*PR created automatically by Jules for task [8540670208211182740](https://jules.google.com/task/8540670208211182740) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with newly identified vulnerability information.

* **Security**
  * Identified potential denial of service vulnerability in code execution API.
  * Unbounded execution without timeout could cause service-wide outages when processing infinite-loop payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->