### PR TITLE
docs: report DoS vulnerability in Docker wait_container

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Container Wait in Execution Endpoint
+Vulnerability Pattern: Denial of Service (DoS) via unbounded asynchronous wait (`docker.wait_container`) when executing untrusted user code.
+Systemic Cause: The server delegates execution to Docker but assumes the container will eventually exit. Because there is no explicit timeout wrapping the asynchronous wait operation, infinite loops in untrusted code will stall the container and the awaiting task indefinitely, leading to resource exhaustion.
+Auditor Note: When orchestrating untrusted code or container runs, always use explicit timeouts like `tokio::time::timeout` to prevent unbounded wait and resource exhaustion vulnerabilities.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,66 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Missing timeout in Docker container execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` orchestrates the execution of untrusted user code by spawning a bespoke Docker container. The backend service waits for the container to exit using `self.docker.wait_container::<String>(&id, None).next().await`.
 
+However, there is no timeout applied to this wait operation. If an attacker submits a payload that runs indefinitely (e.g., an infinite loop `while True: pass` in Python, or `while(1);` in C++), the container will never exit, and the `wait_container` future will pend indefinitely. Because each code execution request occupies a task, multiple requests containing infinite loops will exhaust the server's asynchronous task workers and system resources (due to running containers), leading to a Denial of Service (DoS) vulnerability.
+
+File: `syscore/src/docker/manager.rs`
+Lines:
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        // 6. Wait for execution to finish
+        let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
-
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can repeatedly submit code execution requests (`/api/execute`) containing infinite loops. This will cause the backend to spawn Docker containers that run indefinitely and never get cleaned up, quickly exhausting all server resources (CPU, Memory, and network connections) and making the system completely unresponsive.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send a POST request to the `/api/execute` endpoint with a payload containing an infinite loop:
+   ```json
+   {
+       "language": "python",
+       "code": "while True: pass"
+   }
+   ```
+3. Observe that the API request hangs and never returns a response.
+4. Repeat step 2 multiple times.
+5. Check running Docker containers (`docker ps`) on the host system. You will observe multiple containers stuck running indefinitely.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout for the container wait operation using `tokio::time::timeout`. If the timeout is reached, the server should forcibly kill the container and return an error to the user indicating that the execution timed out.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+// ...
+
+// 6. Wait for execution to finish with a timeout
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+        Some(Ok(res))
+    },
+    Ok(Some(Err(e))) => {
+        tracing::warn!("[Job {}] Container wait error: {}", job_id, e);
+        None
+    },
+    Ok(None) => None,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out, forcibly removing container...", job_id);
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
This submission documents a critical Denial of Service vulnerability present in the backend's code execution endpoint. It fulfills the auditor role requirements by creating a detailed GitHub Issue report in `SECURITY_ISSUE.md` and appending an architectural note to `.jules/sentinel.md` regarding the systemic cause (missing timeout in `docker.wait_container`), without modifying the source code.

---
*PR created automatically by Jules for task [125361737297885848](https://jules.google.com/task/125361737297885848) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability documentation with a newly identified Denial of Service vulnerability related to container execution timeout handling
  * Added remediation guidance for the identified vulnerability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->