### PR TITLE
Report DoS vulnerability in execute container endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-04-10 - Unbounded Wait DoS in Container Execution
+Vulnerability Pattern: Denial of Service via unbounded wait on untrusted execution
+Systemic Cause: The execution engine (Docker manager) awaits the completion of unauthenticated user-submitted code without an explicit timeout, allowing infinite loops to hang async worker threads and exhaust resources.
+Auditor Note: Always enforce strict execution timeouts using tools like tokio::time::timeout when orchestrating untrusted payloads or remote processes to prevent DoS vulnerabilities.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,44 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded wait on container execution allows resource exhaustion
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` contains a critical Denial of Service (DoS) vulnerability. When orchestrating untrusted user code via Docker containers, it starts the container and waits for it to exit using `self.docker.wait_container::<String>(&id, None).next().await;` (around line 203). However, this wait operation lacks a timeout.
 
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+An attacker can submit an infinite loop (e.g., `while True: pass` in Python) via the unauthenticated `/api/execute` endpoint. Since there's no execution timeout on the `wait_container` call, the asynchronous task will await indefinitely. By submitting multiple such requests, an attacker can rapidly exhaust server resources (memory, async worker threads, and open Docker containers), leading to a complete Denial of Service for the backend.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can bring down the `syscore` backend service by submitting a handful of execution requests containing infinite loops. This exhausts server resources and halts all execution processing, causing a complete Denial of Service (DoS) for the platform.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a JSON POST request to the unauthenticated `/api/execute` endpoint.
+3. Provide the payload: `{"language": "python", "code": "while True: pass"}`.
+4. Send the request multiple times in parallel.
+5. Observe that the API requests never complete, and backend resources (such as memory and Docker containers) grow indefinitely, eventually crashing the service.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement explicit timeouts when waiting for untrusted code execution to finish. Wrap the `wait_container` call with `tokio::time::timeout`.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+// Wait for execution to finish with a strict 10-second timeout
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out", job_id);
+        // Force cleanup and return early
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
Identified and documented a critical Denial of Service vulnerability in `syscore/src/docker/manager.rs` where `wait_container` is awaited without a timeout, allowing unauthenticated attackers to exhaust server resources using infinite loops. Output formatted correctly into `SECURITY_ISSUE.md` and appended to `.jules/sentinel.md` as per the Sentinel guidelines.

---
*PR created automatically by Jules for task [17608472554185837520](https://jules.google.com/task/17608472554185837520) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability tracking with a new Denial of Service risk and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->