### PR TITLE
docs: Report hardcoded secret vulnerability in aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Fallback Secret in Aether Upload
+Vulnerability Pattern: Hardcoded default string used as API key fallback via `unwrap_or_else`.
+Systemic Cause: The developer used `unwrap_or_else` on an `env::var` call to provide a default "dev-friendly" value (`update_me_please`) instead of failing securely when the environment variable is missing.
+Auditor Note: Always search for `unwrap_or_else`, `unwrap_or`, and `.env::var` combinations to identify weak default secrets that could be exposed in production environments. Fail securely rather than degrading gracefully into insecure states.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,44 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Hardcoded Secret: Weak default `AETHER_UPLOAD_KEY` bypasses authentication
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a hardcoded fallback secret used for authenticating requests. If the `AETHER_UPLOAD_KEY` environment variable is not set, the application defaults to using the weak static string `"update_me_please"`.
 
 ```rust
 // syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+This default value is hardcoded in the source code. Because this endpoint handles publishing new versions of Aether (uploading executable code), failing to provide a strong environment variable completely breaks authentication, leaving the endpoint open to anyone who reads the source code.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated external attacker can upload malicious software updates (bundles, patches, and DMGs) via the `/api/v1/aether` endpoint. Clients relying on these updates will download and execute the attacker's payload, leading to widespread Remote Code Execution (RCE) on all client machines via Supply Chain compromise.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Ensure the backend is running without `AETHER_UPLOAD_KEY` explicitly set in the environment.
+2. Send a POST request to the `/api/v1/aether` endpoint.
+3. Include the HTTP header `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the upload and publishes the new version instead of returning a `401 Unauthorized`.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Remove the weak default fallback. The application should fail securely if critical secrets are missing. If `AETHER_UPLOAD_KEY` is not provided, the application should either fail to start, or the endpoint should consistently reject all requests.
 
-Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .unwrap_or_else(|_| {
+        tracing::error!("AETHER_UPLOAD_KEY is not set. Rejecting upload.");
+        // Return an unguessable or empty string to guarantee failure,
+        // or handle the Error response directly.
+        "".to_string()
+    });
 
-let file_path = version_dir.join(safe_filename);
+if expected_key.is_empty() || auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Hardcoded Secrets: https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Added a comprehensive vulnerability report for a hardcoded fallback secret in `upload_handler` to `SECURITY_ISSUE.md`, and logged architectural findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16792345885908438242](https://jules.google.com/task/16792345885908438242) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with revised vulnerability assessments and remediation guidance for upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->