### PR TITLE
docs: Add Sentinel security report for DoS in execute endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-20 - Unbounded Wait in Docker Container Execution
+Vulnerability Pattern: Denial of Service (DoS) via resource exhaustion due to missing execution timeouts.
+Systemic Cause: The `/api/execute` endpoint takes untrusted user code and runs it in an ephemeral Docker container via `syscore/src/docker/manager.rs`. However, `docker.wait_container().next().await` is called without any `tokio::time::timeout` wrapper. This allows an attacker to submit an infinite loop (e.g. `while True: pass`), causing the async task to wait indefinitely and eventually exhausting server resources.
+Auditor Note: When auditing execution of untrusted code or container runs, always verify that asynchronous wait operations or blocking calls are bound by an explicit timeout. Look for `await` on container/process futures without a `timeout(...)` wrapper.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,54 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service (DoS): Unbounded wait in Docker container execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` orchestrates untrusted code execution within Docker containers. However, it fails to enforce a timeout when waiting for the container to exit:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs (lines 178-179)
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because `docker.wait_container` can block indefinitely, an attacker can submit an execution payload (e.g., via `/api/execute`) that contains an infinite loop or performs long-running blocking operations (like sleeping). This will cause the `execute` task to hang indefinitely, tying up system resources (both async task workers and Docker containers) leading to a Denial of Service.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can continuously send requests with payloads designed to hang indefinitely (e.g., `while True: pass` in Python). This will exhaust the server's available file descriptors, memory, or async worker threads, completely bringing down the `syscore` API and preventing legitimate users from executing code.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a POST request to the `/api/execute` endpoint.
+3. Provide the payload:
+```json
+{
+  "language": "python",
+  "code": "import time\nwhile True:\n    time.sleep(1)"
+}
+```
+4. Send the request. Notice that the HTTP request hangs and never returns a response.
+5. Send multiple such requests concurrently to observe resource exhaustion.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `docker.wait_container` await operation with a strict timeout using `tokio::time::timeout`. If the timeout is reached, proactively kill/remove the container and return a timeout error to the user.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out", job_id);
+        // Clean up the container explicitly if it times out
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html


### PR DESCRIPTION
Identified and documented a CRITICAL Denial of Service (DoS) vulnerability in the Docker execution pipeline (`syscore/src/docker/manager.rs`). The vulnerability occurs because the `docker.wait_container` async operation is awaited without a timeout, allowing malicious users to execute infinite loops that tie up async workers and system resources indefinitely. 

Included the full GitHub Issue template in `SECURITY_ISSUE.md` and recorded the pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16099120280220036222](https://jules.google.com/task/16099120280220036222) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to identify a Denial of Service vulnerability in container execution that can cause indefinite blocking and resource exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->