### PR TITLE
docs(security): report DoS vulnerability in container execution engine

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-04-15 - Missing Execution Timeout Leads to Denial of Service
+Vulnerability Pattern: Missing timeout in `docker.wait_container`.
+Systemic Cause: The execution engine spawns bespoke containers for unauthenticated users but uses unbounded waits, allowing infinite loops in user code to run indefinitely and exhaust server resources.
+Auditor Note: Always explicitly enforce timeouts for container execution using tools like `tokio::time::timeout`, especially when orchestrating untrusted code.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,44 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ [CRITICAL] Denial of Service: Missing timeout in /api/execute container runs
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
-
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The `ContainerManager::execute` function in `syscore/src/docker/manager.rs` relies on `docker.wait_container::<String>(&id, None).next().await` (at line 227) without a timeout wrapper. The `/api/execute` endpoint processes unauthenticated requests to run user-submitted code in bespoke Docker containers. By submitting a script with an infinite loop, an attacker can cause the `wait_container` future to never resolve, leaking the container instance, network connections, and host memory/CPU. This allows a malicious user to quickly exhaust server resources and achieve a Denial of Service (DoS) against the system.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated remote attacker could send multiple payloads containing infinite loops to the code execution endpoint, exhausting CPU, memory, and container instances on the server. This would result in a complete Denial of Service for the application and potentially crash the host running the containers.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Send an HTTP POST request to `/api/execute` with an infinite loop payload (e.g., Python: `while True: pass`).
+2. Observe that the server spawns a container that never exits, and the backend HTTP response eventually times out.
+3. Check the host's Docker processes using `docker ps`; the spawned container is still consuming resources.
+4. Send enough similar requests to exhaust system limits, taking down the service.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `docker.wait_container` future with `tokio::time::timeout` to enforce a strict upper bound on execution time (e.g., 5-10 seconds) for user-provided scripts.
 
-Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = timeout(Duration::from_secs(10), wait_future).await;
+
+match wait_res {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::warn!("[Job {}] Container execution timed out", job_id);
+        // Ensure container is forcefully killed here if it timed out
+        let _ = self.docker.kill_container(&id, None).await;
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP: Unrestricted Resource Consumption (https://owasp.org/www-community/vulnerabilities/Denial_of_Service)
+- Rust `tokio::time::timeout` (https://docs.rs/tokio/latest/tokio/time/fn.timeout.html)


### PR DESCRIPTION
Reported a CRITICAL Denial of Service (DoS) vulnerability in the unauthenticated `/api/execute` endpoint due to a missing timeout wrapper around `docker.wait_container` in `syscore/src/docker/manager.rs`. Documented the issue using the strict template in `SECURITY_ISSUE.md` and recorded the systemic pattern in `.jules/sentinel.md` as instructed. No actual code was modified.

---
*PR created automatically by Jules for task [7380904892741236914](https://jules.google.com/task/7380904892741236914) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability documentation to describe a denial-of-service risk in container execution, identifying missing execution timeouts as a systemic issue requiring timeout implementation and proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->