### PR TITLE
docs(security): Report DoS via unbounded container execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Container Execution DoS in /api/execute
+Vulnerability Pattern: Missing timeout on Docker container wait (`docker.wait_container`) allowing untrusted user code to execute indefinitely.
+Systemic Cause: The execution logic spawns a container for untrusted user inputs but fails to wrap the asynchronous `.await` operation for container termination with a standard `tokio::time::timeout`. As a result, infinite loops or explicit sleeps consume server resources permanently.
+Auditor Note: Always ensure asynchronous operations involving untrusted input, particularly external process or container executions, are bounded by a timeout to prevent resource exhaustion and Denial of Service.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,52 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ [CRITICAL] Denial of Service (DoS): Unbounded Container Execution via `/api/execute`
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The unauthenticated API endpoint `/api/execute` located in `syscore/src/server/routes.rs` allows execution of untrusted user code (Python/C++) using Docker containers. The execution logic in `syscore/src/docker/manager.rs` awaits the container completion using `docker.wait_container::<String>(&id, None).next().await;` on line 227.
 
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because there is no explicit timeout wrapping this `.await` call, malicious or poorly written user code (such as an infinite loop or `time.sleep(99999)`) will cause the container to run indefinitely. This will tie up server resources, leaving the background Docker process and the Rust `execute` future pending forever.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker could repeatedly submit code containing infinite loops to the `/api/execute` endpoint. This will quickly exhaust the system's process limits, memory, and CPU (even with the 1 CPU/256MB limit), leading to a complete Denial of Service (DoS) for the entire application, preventing legitimate users from executing code.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Send a POST request to the `/api/execute` endpoint without authentication.
+2. Input the following JSON payload:
+   ```json
+   {
+     "language": "python",
+     "code": "while True: pass"
+   }
+   ```
+3. Observe that the API request never completes, and the Docker container remains running on the host system indefinitely. Repeated requests will accumulate orphaned containers and exhaust resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
-
-Example fix:
+Wrap the `wait_container` future with a timeout using `tokio::time::timeout`. For example:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Container execution timed out", job_id);
+        // Ensure the container is forcefully removed
+        let _ = self.docker.remove_container(&id, Some(bollard::container::RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        })).await;
+        return Err("Execution timed out".to_string());
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- [OWASP: Denial of Service (DoS)](https://owasp.org/www-community/attacks/Denial_of_Service)
+- [CWE-400: Uncontrolled Resource Consumption](https://cwe.mitre.org/data/definitions/400.html)


### PR DESCRIPTION
Identified a CRITICAL Denial of Service (DoS) vulnerability in `syscore/src/docker/manager.rs` where Docker containers running untrusted user code via `/api/execute` are awaited without a timeout (`tokio::time::timeout`). This allows malicious payloads (e.g., infinite loops) to permanently exhaust server resources. Created the `SECURITY_ISSUE.md` report and updated `.jules/sentinel.md` as requested. No source code was modified.

---
*PR created automatically by Jules for task [17613809139698073007](https://jules.google.com/task/17613809139698073007) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated security vulnerability documentation to comprehensively address a potential denial of service condition affecting the execute endpoint. The issue involves unbounded container execution processes operating without proper timeout constraints. Enhanced guidance now includes detailed remediation recommendations such as implementing timeout mechanisms for container termination, resource exhaustion prevention strategies, and automated cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->