### PR TITLE
Update Sentinel Journal with DoS Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Execution in Code Runner
+Vulnerability Pattern: Denial of Service (DoS) via unbounded wait on untrusted execution.
+Systemic Cause: The `/api/execute` endpoint accepts unauthenticated code submissions and waits for the Docker container to finish without enforcing a timeout. This allows attackers to run infinite loops, indefinitely tying up server resources and connection handlers.
+Auditor Note: Always verify that execution of untrusted user code or interactions with external processes/containers are wrapped with strict timeouts (e.g., `tokio::time::timeout`) to prevent resource exhaustion and DoS.


### PR DESCRIPTION
Appended a new entry to `.jules/sentinel.md` documenting a critical DoS vulnerability found in `syscore/src/docker/manager.rs` where an unauthenticated API endpoint `/api/execute` lacked an execution timeout on user-provided code, leading to possible unbounded resource exhaustion.

---
*PR created automatically by Jules for task [17757528791565598824](https://jules.google.com/task/17757528791565598824) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal security audit documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->