### PR TITLE
docs: log critical DoS vulnerability in wait_container

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Wait on Untrusted Container Execution
+Vulnerability Pattern: Missing timeout when waiting for async operations involving user-controlled code execution (e.g., `docker.wait_container`).
+Systemic Cause: The execution pipeline in `syscore/src/docker/manager.rs` does not enforce strict timeouts on the untrusted workload container, assuming the workload will naturally complete. This causes the async task to hang indefinitely if the user submits an infinite loop.
+Auditor Note: Always verify that any operations executing untrusted code or container workloads use explicit timeouts (e.g., `tokio::time::timeout` in Rust) to prevent unauthenticated Denial of Service via resource exhaustion.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,46 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service: Unbounded Wait on Untrusted Container Execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` does not enforce a timeout when waiting for a Docker container to finish execution. Specifically, `docker.wait_container` is awaited indefinitely:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because the `/api/execute` endpoint processes unauthenticated requests to run user-provided code, a malicious actor can submit code containing an infinite loop (e.g., `while True: pass` in Python). The backend will spawn a container and wait indefinitely for it to complete without ever releasing the associated async task or Docker container resources.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can submit multiple requests with infinite loops, tying up async worker threads and exhausting Docker resources (such as maximum concurrent containers or server memory/CPU). This will lead to a complete Denial of Service (DoS) for the execution backend and the entire application.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a POST request to the `/api/execute` endpoint.
+3. Provide the JSON payload: `{"language": "python", "code": "while True: pass"}`.
+4. Send the request.
+5. Observe that the API request hangs indefinitely and the associated Docker container runs continuously without being terminated or timing out.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `wait_container` future with an explicit timeout using `tokio::time::timeout`. If the timeout expires, forcibly stop and remove the container.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out", job_id);
+        let _ = self.docker.stop_container(&id, None).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html


### PR DESCRIPTION
This PR logs the findings of a security audit uncovering a DoS vector in the untrusted container execution logic due to the lack of an explicit timeout in `wait_container`. It adheres to the negative constraint of not modifying the actual codebase to fix the bug, strictly providing the intel for developers.

---
*PR created automatically by Jules for task [1812818376399456983](https://jules.google.com/task/1812818376399456983) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security advisories documenting a denial-of-service vulnerability related to container execution operations that lack enforced timeout limits, which could result in indefinite waiting when processing untrusted workloads.
  * Added security remediation guidance recommending the implementation of explicit timeout mechanisms and automatic container termination on timeout expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->