### PR TITLE
Report DoS vulnerability in container execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Asynchronous Wait in Untrusted Code Execution
+Vulnerability Pattern: Denial of Service (DoS) via unbounded asynchronous wait (`docker.wait_container`) without a timeout.
+Systemic Cause: When executing untrusted user-submitted code in an isolated container environment, the system trusts the container to eventually terminate. However, if the code runs an infinite loop or blocks indefinitely, the `wait_container` future never completes, causing the backend to hang and potentially exhaust asynchronous task slots and server resources.
+Auditor Note: Always verify that asynchronous waits involving external processes or untrusted code execution are bounded by strict timeouts (e.g., using `tokio::time::timeout`). Look for missing timeout handling on operations like `wait_container`, process wait, or network requests targeting external systems.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,64 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service: Unbounded Wait on Container Execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` contains a Denial of Service (DoS) vulnerability due to an unbounded asynchronous wait.
+When executing untrusted code via the `execute` method, the code waits indefinitely for the container to finish executing:
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+If a user submits code containing an infinite loop (e.g., `while True: pass` in Python), the container will run indefinitely. Because there is no explicit timeout wrapping the `wait_container` future, the backend service will hang on this request forever, tying up asynchronous workers and resources. An attacker could submit multiple such requests to quickly exhaust the server's execution slots, leading to a complete Denial of Service.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated or authenticated attacker can submit malicious payloads containing infinite loops to the code execution endpoint. This causes the Docker containers to run indefinitely and the backend API to block on those requests forever. Multiple such submissions will exhaust system resources (CPU, Memory, and asynchronous task slots), leading to a complete Denial of Service for all users attempting to execute code.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the `syscore` backend service with Docker enabled.
+2. Send a POST request to the `/api/v1/execute` endpoint (or equivalent code execution endpoint) with a Python payload containing an infinite loop:
+   ```json
+   {
+       "language": "python",
+       "code": "while True:\n    pass"
+   }
+   ```
+3. Observe that the API request never completes and hangs indefinitely.
+4. Check the running Docker containers (`docker ps`) and observe that the execution container continues running.
+5. Send multiple such requests to completely exhaust the server's concurrent execution capacity.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout using `tokio::time::timeout` when awaiting the container execution. Additionally, ensure the container is forcefully killed and cleaned up if the timeout is reached.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+// 6. Wait for execution to finish with a timeout
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let timeout_duration = Duration::from_secs(10); // Example 10-second timeout
+
+match timeout(timeout_duration, wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out. Forcefully killing container.", job_id);
+        // Ensure the container is forcefully stopped/killed before cleaning up
+        let _ = self.docker.kill_container::<String>(&id, None).await;
+        return Err("Execution timed out".to_string());
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- OWASP Denial of Service: https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
Documents a CRITICAL Denial of Service (DoS) vulnerability identified in `syscore/src/docker/manager.rs` where an unbounded asynchronous wait allows untrusted code to hang the backend execution service. The report is formatted for GitHub Issues and added to `SECURITY_ISSUE.md`, and the architectural pattern is recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15493462511802240430](https://jules.google.com/task/15493462511802240430) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability documentation with revised assessment criteria and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->