### PR TITLE
docs(security): report missing timeout in Docker execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Missing Timeout in Container Execution
+Vulnerability Pattern: Missing explicit timeout on untrusted execution wait loops (e.g., `docker.wait_container`).
+Systemic Cause: The `execute` function in `syscore/src/docker/manager.rs` does not enforce an explicit timeout when waiting for a Docker container to complete execution. This omission allows submitted code with infinite loops to run indefinitely and exhaust system resources.
+Auditor Note: Always check for missing bounds and timeouts when interacting with external processes or Docker APIs. When orchestrating untrusted code, ensure mechanisms like `tokio::time::timeout` are enforced to prevent unbounded waits and DoS vulnerabilities.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,52 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Missing timeout in Docker container execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
-
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The `execute` function in `syscore/src/docker/manager.rs` orchestrates untrusted user code execution by spawning Docker containers. However, it waits for the container to finish using `self.docker.wait_container::<String>(&id, None).next().await;` without applying any explicit timeout mechanism.
+This means that if malicious code submitted via the execution API contains an infinite loop or blocks indefinitely, the `wait_container` await point will never return. The backend will hang on this request, and the Docker container will run indefinitely, exhausting server resources over time.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker can submit code with infinite loops (e.g., `while True: pass` in Python), causing a Denial of Service (DoS). By repeatedly sending such requests, the attacker can quickly exhaust server memory, CPU, and available connection/worker threads, rendering the application and API completely unavailable.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send a request to the code execution endpoint that triggers `ContainerManager::execute`.
+3. Provide a payload that executes an infinite loop. For Python:
+   ```json
+   {
+     "language": "python",
+     "code": "while True: pass"
+   }
+   ```
+4. Observe that the API request hangs indefinitely and never returns.
+5. Check the system's Docker processes using `docker ps` and note that the container `okernel-job-<uuid>` continues to run indefinitely, consuming CPU resources.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement an explicit timeout when waiting for the container to finish using `tokio::time::timeout`. If the timeout expires, the function should log the event, stop the container, and return an error to prevent unbounded execution.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+// Set a reasonable execution timeout, e.g., 10 seconds.
+match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(_) => {
+        tracing::warn!("[Job {}] Wait failed or container crashed specifically", job_id);
+    }
+    Err(_) => {
+        tracing::error!("[Job {}] Execution timed out", job_id);
+        // Cleanup routine will handle stopping/removing the container
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- OWASP Denial of Service: https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
Reported a CRITICAL Denial of Service (DoS) vulnerability in `syscore/src/docker/manager.rs` caused by a missing explicit timeout in the untrusted container execution wait loop (`docker.wait_container`). Updated `SECURITY_ISSUE.md` with full reproduction steps and remediation utilizing `tokio::time::timeout`. Recorded architectural learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6168508715453708815](https://jules.google.com/task/6168508715453708815) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing newline formatting in security audit records.

* **Documentation**
  * Updated security vulnerability documentation with revised findings regarding container execution timeout handling and corresponding remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->