### PR TITLE
docs: Report CRITICAL DoS in container execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded Wait in Container Orchestration
+Vulnerability Pattern: Denial of Service (DoS) via unbounded `await` on container execution (`docker.wait_container`).
+Systemic Cause: The backend application acts as an orchestrator for untrusted code execution but blindly trusts that the spawned container will eventually terminate. The missing explicit timeout allows user-submitted infinite loops to run indefinitely.
+Auditor Note: Always verify that any function awaiting external processes, containers, or untrusted code execution uses explicit timeouts (e.g., `tokio::time::timeout`) to prevent resource exhaustion and DoS.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,48 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Denial of Service: Unbounded Wait in Docker Container Execution
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` launches a docker container to execute user-submitted code. However, it waits for the container to exit using an unbounded `.await` on `wait_container`.
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+If a user submits code containing an infinite loop (e.g., `while True: pass` in Python), the container will run indefinitely. The backend thread will hang forever waiting for the container to finish. This missing execution timeout allows malicious or poorly written code to tie up backend resources, leading to resource exhaustion.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An attacker can perform a Denial of Service (DoS) attack by submitting multiple requests with code that enters an infinite loop. This will exhaust server threads, memory, and Docker container limits, rendering the code execution service unavailable for other users. Complete exhaustion could crash the `syscore` backend.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Send an execution payload to the `/api/execute` endpoint via a POST request with an infinite loop.
+   Payload example: `{"language": "python", "code": "while True: pass"}`
+3. Observe that the API request never completes and the container runs indefinitely.
+4. Send multiple such requests to exhaust server capabilities and observe the Denial of Service.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Implement a strict execution timeout. Wrap the `wait_container` future with `tokio::time::timeout` so that if the container execution exceeds a specified duration (e.g., 5-10 seconds), the wait is cancelled and the container is forcefully killed.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use tokio::time::{timeout, Duration};
 
-let file_path = version_dir.join(safe_filename);
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+let wait_res = match timeout(Duration::from_secs(10), wait_future).await {
+    Ok(res) => res,
+    Err(_) => {
+        tracing::error!("[Job {}] Container execution timed out", job_id);
+        // Ensure container is killed and cleaned up here
+        let _ = self.cleanup_container(&id).await;
+        return Err("Execution timed out".to_string());
+    }
+};
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Tokio Timeout Documentation: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
+- OWASP DoS Vulnerabilities: https://owasp.org/www-community/attacks/Denial_of_Service


### PR DESCRIPTION
Reported a CRITICAL Denial of Service (DoS) vulnerability in the backend's Docker container execution logic (`syscore/src/docker/manager.rs`). The backend orchestrates untrusted code but uses an unbounded `.await` on `docker.wait_container`, allowing user-submitted infinite loops to run indefinitely and exhaust server resources. Documented the issue in `SECURITY_ISSUE.md` and added an entry to `.jules/sentinel.md` outlining the vulnerability pattern.

---
*PR created automatically by Jules for task [13320625108515725289](https://jules.google.com/task/13320625108515725289) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised critical security issue documentation to address a denial-of-service vulnerability caused by unbounded asynchronous container execution.
  * Added a new detection rule for identifying potential denial-of-service conditions in container operations.
  * Updated remediation guidance with recommended approaches for enforcing execution timeouts and implementing cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->