### PR TITLE
Report DoS vulnerability in Docker manager execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Unbounded execution of untrusted code in Docker manager
+Vulnerability Pattern: Missing execution timeout on remote/untrusted code execution via `wait_container`.
+Systemic Cause: Trusting user-submitted code to naturally terminate. While memory/CPU bounds are present in `HostConfig`, the lack of wall-clock timeouts for execution jobs enables attackers to hoard running container instances and exhaust host resources or connection concurrency limits over time.
+Auditor Note: Always check usages of unbounded `.await` on external processes, tasks, or API calls, particularly those executing user-provided logic or interacting with Docker. Ensure an explicit timeout (e.g., `tokio::time::timeout`) is used and accompanied by reliable cleanup code (e.g., forcing a process kill).

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,59 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL DoS: Unbounded execution of untrusted code in Docker manager
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `execute` function in `syscore/src/docker/manager.rs` spawns a Docker container to run untrusted, user-submitted code (Python or C++) without enforcing an execution timeout. It awaits completion using `self.docker.wait_container::<String>(&id, None).next().await`. Because no timeout is provided, if the user submits code containing an infinite loop or an intentionally long-running operation, the container will run indefinitely.
 
 ```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+// syscore/src/docker/manager.rs
+// 6. Wait for execution to finish
+let wait_res = self.docker.wait_container::<String>(&id, None).next().await;
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+While a memory constraint (256 MB) and CPU share limit are configured via `HostConfig`, the lack of a wall-clock timeout allows an attacker to exhaust connection pools, memory, and CPU cycles over time by submitting multiple non-terminating jobs. This prevents legitimate users from executing code and can bring down the entire code execution service.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+A Denial of Service (DoS) attack where an attacker can submit multiple infinite loop scripts to permanently consume server resources (e.g., container slots, memory, and CPU limits) rendering the `/api/execute` endpoint and potentially the entire host unresponsive or permanently degraded until manual intervention occurs.
 
 🛠️ Steps to Reproduce
 1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+2. Construct a request to the `/api/execute` endpoint specifying the `Python` language.
+3. Submit the following code payload: `while True: pass`
+4. Send the request multiple times.
+5. Observe that the API endpoint becomes permanently blocked waiting for the containers to finish, as `wait_container` never returns. Use `docker ps` to verify that multiple `okernel-job-*` containers are running endlessly.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Wrap the `wait_container` operation in an asynchronous timeout such as `tokio::time::timeout`. If the timeout expires before the container finishes, forcefully kill and remove the container.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
+use std::time::Duration;
+use tokio::time::timeout;
 
-let file_path = version_dir.join(safe_filename);
+// 6. Wait for execution to finish with a timeout
+let timeout_duration = Duration::from_secs(10); // Example 10 second timeout
+let wait_future = self.docker.wait_container::<String>(&id, None).next();
+
+match timeout(timeout_duration, wait_future).await {
+    Ok(Some(Ok(res))) => {
+        tracing::debug!("[Job {}] Container exited with code {}", job_id, res.status_code);
+    }
+    Ok(Some(Err(e))) => {
+        tracing::warn!("[Job {}] Wait failed: {}", job_id, e);
+    }
+    Ok(None) => {
+        tracing::warn!("[Job {}] Stream ended unexpectedly", job_id);
+    }
+    Err(_) => {
+        tracing::warn!("[Job {}] Execution timed out after {:?}", job_id, timeout_duration);
+        // Container must be forcefully stopped
+        let _ = self.docker.stop_container(&id, None).await;
+    }
+}
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- Docker Engine API `wait`: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerWait
+- CWE-400: Uncontrolled Resource Consumption: https://cwe.mitre.org/data/definitions/400.html


### PR DESCRIPTION
As Sentinel, I conducted a security audit and identified a CRITICAL Denial of Service (DoS) vulnerability in `syscore/src/docker/manager.rs`. The `execute` function awaits `wait_container` without a timeout, allowing untrusted code (such as infinite loops) to run indefinitely and exhaust host resources.

I have documented this vulnerability in `SECURITY_ISSUE.md` strictly following the requested emoji template, providing steps to reproduce and recommended remediation (wrapping the future in `tokio::time::timeout`). I also recorded this systemic architectural pattern in `.jules/sentinel.md`.

No source code was modified, respecting the strict auditing boundaries. All tests were executed and pass, demonstrating that this documentation update did not break existing functionality.

---
*PR created automatically by Jules for task [5275532527311684142](https://jules.google.com/task/5275532527311684142) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security issue documentation to reflect newly identified vulnerabilities.
  * Added guidance on container execution timeout handling to prevent potential denial-of-service conditions.

* **Security**
  * Revised security advisory information with updated remediation recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->