### PR TITLE
Document Critical Broken Auth Vulnerability in Aether Uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Fallback for Secrets in Aether
+Vulnerability Pattern: Broken Auth via weak default fallback (`unwrap_or_else` providing a default string for missing environment variable secrets).
+Systemic Cause: The application attempts to handle missing environment variables gracefully using `unwrap_or_else` but provides a predictable, weak default key (`"update_me_please"`), exposing critical endpoints if configuration management fails.
+Auditor Note: Always audit `std::env::var` usage for secrets. Secrets must fail securely if missing, not fall back to weak defaults. Look for `unwrap_or_else` and `unwrap_or` patterns on sensitive environment variables.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,39 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for AETHER_UPLOAD_KEY allows unauthorized uploads
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability due to a weak default fallback for the `AETHER_UPLOAD_KEY` environment variable. When the `AETHER_UPLOAD_KEY` environment variable is not set, the application uses `unwrap_or_else` to fall back to the hardcoded string `"update_me_please"`.
 
 ```rust
 // syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+Because environment variables representing secrets may inadvertently be omitted during deployment, an attacker can use the known default key `"update_me_please"` to bypass authentication on the critical upload endpoint (`/api/v1/aether`).
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can upload malicious software updates, bundles, or patches to the Aether release storage, compromising the integrity of the update system. This could lead to a supply chain attack where malicious updates are distributed to clients, resulting in widespread Remote Code Execution (RCE) on user machines.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
 2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
 3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
+4. Include text form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
+5. Include a file upload field named `file` containing the malicious payload.
 6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+7. Observe that the server accepts the request and publishes the uploaded file.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Remove the weak default fallback for `AETHER_UPLOAD_KEY`. The application should reject the request securely if the environment variable is not provided, enforcing the requirement for a strong, explicit secret.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
-
-let file_path = version_dir.join(safe_filename);
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string()))?;
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-1188: Initialization of a Resource with an Insecure Default: https://cwe.mitre.org/data/definitions/1188.html


### PR DESCRIPTION
Documented a critical broken authentication vulnerability caused by a weak default fallback (`update_me_please`) for the `AETHER_UPLOAD_KEY` environment variable in the `syscore/src/server/aether.rs` upload handler. Appended the systemic architectural pattern learning to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [18438761409083399742](https://jules.google.com/task/18438761409083399742) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated security documentation to address authentication configuration best practices and secure environment variable handling
* Enhanced guidance to prevent unauthorized access through insecure default credential fallback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->