### PR TITLE
Report broken auth vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-18 - Weak Default Fallback for Authentication Keys
+Vulnerability Pattern: Broken Auth via fallback to a weak default credential using `unwrap_or_else` on an environment variable.
+Systemic Cause: To prevent crashes during local testing, sensitive environment variables like API keys are given default hardcoded string fallbacks in the application logic. When deployed to production without these variables explicitly set, the system silently relies on the insecure defaults.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,37 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for AETHER_UPLOAD_KEY enables unauthorized uploads
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
+The `upload_handler` function in `syscore/src/server/aether.rs` implements authentication by checking the `Authorization` header against the `AETHER_UPLOAD_KEY` environment variable. However, if this environment variable is not set, it falls back to a weak, hardcoded default value (`"update_me_please"`) using `unwrap_or_else`.
 
 ```rust
 // syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
 ```
 
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+This ensures the endpoint is always accessible via a known default credential if the system administrator forgets to properly configure the environment variable, entirely defeating the authentication mechanism.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker can use the known default key `"update_me_please"` to bypass authentication and upload malicious payloads to the Aether release endpoint. Given that this endpoint handles file uploads, an attacker could exploit this to upload malware or overwrite files on the host machine.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
 2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+3. Include the default authorization header: `Authorization: Bearer update_me_please`.
+4. Send the request with valid form data.
+5. Observe that the server accepts the upload with a `201 Created` response, successfully bypassing the intended authentication.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
+Remove the `unwrap_or_else` fallback. The endpoint should securely fail and reject all uploads if the key is not explicitly configured.
 
 Example fix:
 ```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
-
-let file_path = version_dir.join(safe_filename);
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server upload key not configured".to_string()))?;
 ```
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Adds a GitHub issue report detailing a Broken Auth vulnerability found in `syscore/src/server/aether.rs` where the `upload_handler` falls back to a weak default credential using `unwrap_or_else`. It also updates the Sentinel journal in `.jules/sentinel.md` to document the architectural learnings. No application code was modified.

---
*PR created automatically by Jules for task [13848307021327043743](https://jules.google.com/task/13848307021327043743) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal security documentation and auditor guidance regarding system authentication and file handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->