### PR TITLE
🛡️ CRITICAL Broken Auth: Hardcoded Fallback Secret in aether.rs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-24 - Hardcoded Secret Fallback via unwrap_or_else
+Vulnerability Pattern: Weak or hardcoded defaults for sensitive environment variables using `unwrap_or_else` or `unwrap_or`.
+Systemic Cause: Developers providing a default value to avoid app crashes when the environment is not fully configured, which unintentionally introduces a backdoor if deployed without the proper environment variables.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -1,48 +1,23 @@
-Title: 🛡️ CRITICAL Arbitrary File Write: Unsanitized filename in Aether version upload handler
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded Fallback Secret in aether.rs upload_handler
 
 🚨 Severity
 CRITICAL
 
 💡 Description
-The `upload_handler` function in `syscore/src/server/aether.rs` contains an Arbitrary File Write vulnerability due to the lack of sanitization on the `filename` provided in the multipart form data.
-In Rust, `std::path::PathBuf::join` replaces the entire base path if the appended string is an absolute path. The `filename` extracted from `multipart.next_field()` is directly joined to `version_dir`:
-
-```rust
-// syscore/src/server/aether.rs
-let file_path = version_dir.join(&filename);
-tokio_fs::write(&file_path, &file_bytes).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-```
-
-Because `filename` is attacker-controlled and unsanitized, an attacker can provide an absolute path (e.g., `/etc/passwd` or `/root/.ssh/authorized_keys`) as the `filename`. `PathBuf::join` will discard the `version_dir` and write the uploaded file contents directly to the attacker-specified absolute path on the host filesystem.
+The `upload_handler` function in `syscore/src/server/aether.rs` attempts to verify an authorization token using an environment variable `AETHER_UPLOAD_KEY`. However, if the environment variable is not set, it utilizes `unwrap_or_else` to fall back to a hardcoded, predictable string `"update_me_please"`. This hardcoded fallback acts as a backdoor, allowing any unauthorized party to authenticate and upload potentially malicious files. The vulnerability is located exactly on line 315.
 
 🎯 Potential Impact
-An authenticated attacker (even using the weak default `AETHER_UPLOAD_KEY` of "update_me_please") can overwrite arbitrary files on the system with the permissions of the user running the `syscore` backend service. This can lead to Remote Code Execution (RCE) by overwriting `.ssh/authorized_keys`, cron jobs, or system binaries, leading to complete system compromise.
+An unauthenticated attacker could upload malicious files or arbitrarily replace Aether software versions with compromised payloads, leading to a massive supply-chain attack when clients update.
 
 🛠️ Steps to Reproduce
-1. Start the `syscore` backend service.
-2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
-3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
-4. Include form fields for `version` (e.g., `1.0.0`), `description`, and `changelog`.
-5. Include a file upload field with the name `file`. Set the filename parameter in the Content-Disposition header to an absolute path, such as `/tmp/pwned.txt`.
-6. Send the request.
-7. Observe that the file `pwned.txt` is created in `/tmp` containing the uploaded payload, instead of within the intended `storage/aether/1.0.0/` directory.
+1. Start the backend server without `AETHER_UPLOAD_KEY` environment variable set.
+2. Send an HTTP POST request to the upload endpoint with the header `Authorization: Bearer update_me_please`.
+3. Include a multipart payload with `version`, `channel`, `file`, etc.
+4. Observe that the server accepts and processes the upload with a `201 CREATED` status code.
 
 ✅ Recommended Remediation
-Implement strict path sanitization for the `filename` extracted from the multipart request before using it with `PathBuf::join`.
-1. Reject any filename containing path separators (`/` or `\`).
-2. Alternatively, extract only the final file component using `std::path::Path::new(&filename).file_name()`.
-3. Ensure the resolved path remains within the intended storage directory bounds.
-
-Example fix:
-```rust
-let safe_filename = std::path::Path::new(&filename)
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or((StatusCode::BAD_REQUEST, "Invalid filename".to_string()))?;
-
-let file_path = version_dir.join(safe_filename);
-```
+Remove the `unwrap_or_else` fallback. Instead, the application should either fail to start if the `AETHER_UPLOAD_KEY` is missing from the environment, or the `upload_handler` should immediately reject uploads if the key is unset.
 
 🔗 References
-- Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
-- OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+- OWASP Top 10 - Broken Access Control
+- CWE-798: Use of Hard-coded Credentials


### PR DESCRIPTION
Identified and documented a CRITICAL Broken Auth vulnerability in syscore/src/server/aether.rs where the AETHER_UPLOAD_KEY environment variable falls back to a hardcoded string via unwrap_or_else, acting as a backdoor.

---
*PR created automatically by Jules for task [4499199824976265011](https://jules.google.com/task/4499199824976265011) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Security audit documentation expanded with critical vulnerability entries covering hardcoded secret fallbacks causing authentication bypass and arbitrary file write risks from path traversal.
  * Security issue guide updated to include detailed reproduction steps, severity assessment, and remediation recommendations for identified vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->