### PR TITLE
Report Broken Auth Vulnerability in Aether Upload API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Broken Auth: Weak Default Credential for Aether Upload API
+Vulnerability Pattern: Broken Auth due to weak default credential fallback in environment variables.
+Systemic Cause: The system uses `unwrap_or_else` on `std::env::var("AETHER_UPLOAD_KEY")` and provides a weak default string instead of failing securely when the environment variable is absent.
+Auditor Note: Always check for `unwrap_or_else` or `unwrap_or` on environment variables that represent secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak Default Credential for Aether Upload API
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability due to a weak default fallback for the authentication key. If the `AETHER_UPLOAD_KEY` environment variable is not explicitly set, the system falls back to the hardcoded default `"update_me_please"`:
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This allows any attacker who knows this default key to bypass authentication on a sensitive API route intended for publishing new versions of the Aether application.
+
+🎯 Potential Impact
+An unauthorized user can publish malicious updates, bundles, or patches to the Aether application. This can lead to the distribution of malware to all clients that download the update, resulting in a widespread supply chain attack and complete compromise of end-user systems.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the weak default authentication header: `Authorization: Bearer update_me_please`.
+4. Include the necessary form fields (`version`, `file`, etc.).
+5. Send the request and observe that the payload is successfully accepted and published (HTTP 201 Created).
+
+✅ Recommended Remediation
+Remove the weak default fallback. The system should securely fail if the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "AETHER_UPLOAD_KEY is not configured".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-1188: Initialization of a Resource with an Insecure Default: https://cwe.mitre.org/data/definitions/1188.html


### PR DESCRIPTION
- Appended a new CRITICAL vulnerability report to SECURITY_ISSUE.md.
- Documented a Broken Auth vulnerability caused by a weak default fallback (`"update_me_please"`) in the `AETHER_UPLOAD_KEY` environment variable within `syscore/src/server/aether.rs`.
- Recorded the systemic pattern and auditor notes in `.jules/sentinel.md` as required by the mission.

---
*PR created automatically by Jules for task [14950814360960000259](https://jules.google.com/task/14950814360960000259) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive security guidance including audit notes on secure file handling practices and a critical security advisory addressing a Broken Authentication vulnerability in the upload API involving weak default credentials. Review remediation recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->