### PR TITLE
docs: Append broken auth vulnerability report

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Default Credential in Aether File Upload
+Vulnerability Pattern: Broken Auth via fallback to a weak default credential using `unwrap_or_else`.
+Systemic Cause: The `upload_handler` attempts to provide a default value for the `AETHER_UPLOAD_KEY` environment variable if it is missing, rather than failing securely.
+Auditor Note: Always check usages of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,37 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a fallback to a weak default credential if the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+If the environment variable is missing, any user who knows the hardcoded key "update_me_please" can successfully authenticate to the upload endpoint.
+
+🎯 Potential Impact
+An unauthorized user could authenticate to the `/api/v1/aether` endpoint and upload malicious versions of the Aether application, potentially distributing malware to users checking for updates.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the upload request and processes it.
+
+✅ Recommended Remediation
+Remove the fallback to a weak default credential. Instead, fail securely if the `AETHER_UPLOAD_KEY` is not present in the environment.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
Added a critical Broken Auth vulnerability report to `SECURITY_ISSUE.md` regarding the `upload_handler` falling back to a weak default credential `"update_me_please"`. Also added the architectural learning to the Sentinel journal `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3768291537360727069](https://jules.google.com/task/3768291537360727069) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability documentation with new hardcoded credential vulnerability entry.
  * Added detailed remediation guidance for authentication-related security issues with reproduction steps and mitigation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->