### PR TITLE
docs: append Sentinel security audit findings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Weak Default Fallback for Missing Credentials
+Vulnerability Pattern: A critical security check falls back to a hardcoded weak string ("update_me_please") when the intended environment variable is missing using `unwrap_or_else`.
+Systemic Cause: Developer convenience or local testing setups leaking into production pathways without failing securely upon missing configuration.
+Auditor Note: Systematically verify all usages of `std::env::var("...").unwrap_or_else` or `unwrap_or` for secrets. Missing credentials must fail closed (deny access or panic at startup) rather than supplying a vulnerable default.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,40 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded Weak Default Credential in Aether Upload
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability. The code attempts to read the `AETHER_UPLOAD_KEY` environment variable to authenticate uploads. However, if this environment variable is missing, it falls back to a hardcoded, trivially guessable string `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+This means that in environments where the key is not explicitly configured, the API becomes practically unauthenticated, allowing any attacker who discovers the fallback string to push new versions to the storage directory.
+
+🎯 Potential Impact
+An unauthorized attacker can upload malicious binaries, bundles, or patches as new versions. This directly compromises the integrity of the software distribution channel, potentially enabling Remote Code Execution (RCE) on client machines that download the compromised updates.
+
+🛠️ Steps to Reproduce
+1. Deploy the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Include standard upload form fields and a file.
+5. Observe that the server accepts the upload with a 201 Created status, successfully publishing a malicious version.
+
+✅ Recommended Remediation
+Remove the weak fallback entirely. Fail securely and return an internal server error or refuse startup if the secret is not configured.
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "AETHER_UPLOAD_KEY is not configured".to_string()))?;
+```
+Alternatively, perform this check during application startup and panic if the required secrets are missing.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This commit contains the intelligence report generated by Sentinel. It documents a critical broken authentication vulnerability found in `syscore/src/server/aether.rs` where an insecure fallback credential (`update_me_please`) is used if the `AETHER_UPLOAD_KEY` environment variable is missing. The finding has been appended to `SECURITY_ISSUE.md` using the standard GitHub Issue template. Additionally, the architectural pattern and systemic cause have been recorded in the Sentinel journal at `.jules/sentinel.md`.

No application source code was modified, strictly adhering to the Sentinel engagement rules.

---
*PR created automatically by Jules for task [921016230147545616](https://jules.google.com/task/921016230147545616) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation highlighting critical security vulnerabilities related to hardcoded credential fallbacks and authentication weaknesses in upload functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->