### PR TITLE
docs: Report Broken Auth Vulnerability in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-05-12 - Weak Default Fallback for Secrets
+Vulnerability Pattern: Broken Auth via weak default fallback in `unwrap_or_else` on environment variables.
+Systemic Cause: The application attempts to handle missing configuration gracefully but does so insecurely by substituting a known, hardcoded secret (`"update_me_please"`) when `AETHER_UPLOAD_KEY` is missing.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,49 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for Aether upload key
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default fallback for the `AETHER_UPLOAD_KEY` environment variable. If the environment variable is not set, the application defaults to using `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+This means that in any environment where the administrator forgets to explicitly set `AETHER_UPLOAD_KEY`, an attacker can bypass authentication by simply providing the known default key.
+
+🎯 Potential Impact
+An unauthenticated attacker can upload arbitrary files to the server using the default credentials, potentially overwriting existing releases, serving malicious updates to users, or combining this with other vulnerabilities (like arbitrary file write) to achieve Remote Code Execution.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting `AETHER_UPLOAD_KEY`.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Include necessary form fields (`version`, `file`, etc.).
+5. Send the request.
+6. Observe that the request is accepted (201 Created) instead of being rejected as unauthorized (401).
+
+✅ Recommended Remediation
+Fail securely when the required environment variable is missing. Do not provide a weak default fallback for credentials or secrets.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
+```
+Alternatively, panic on startup if required secrets are not provided.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-10/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This PR adds a new security finding to `SECURITY_ISSUE.md` detailing a Broken Authentication vulnerability caused by a weak default fallback (`"update_me_please"`) for the `AETHER_UPLOAD_KEY` environment variable in the `upload_handler` (`syscore/src/server/aether.rs`). It also updates the Sentinel journal `.jules/sentinel.md` with notes on the vulnerability pattern and auditing guidelines.

No codebase files were modified in this PR.

---
*PR created automatically by Jules for task [15170680081502697391](https://jules.google.com/task/15170680081502697391) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit documentation regarding weak default credential handling
  * Added documentation for a critical authentication vulnerability in upload functionality when credentials are missing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->