### PR TITLE
docs(security): document critical arbitrary file write and broken auth in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Default Credentials in Aether Upload Auth
+Vulnerability Pattern: Broken Authentication via hardcoded default API key fallback (`unwrap_or_else(|_| "update_me_please".to_string())`).
+Systemic Cause: When retrieving secrets from environment variables, developers sometimes provide a weak default value to simplify local development or testing, which inadvertently bypasses security controls in production if the environment variable is not explicitly set.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,49 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Default Hardcoded API Key in Aether Upload Handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a hardcoded, weak default API key used for authenticating version uploads.
+When verifying the `Authorization` header, the code attempts to read the `AETHER_UPLOAD_KEY` environment variable. If the variable is not set, it defaults to the predictable string `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+This ensures that any deployment where the administrator forgets or fails to explicitly set `AETHER_UPLOAD_KEY` is completely unprotected against unauthorized uploads.
+
+🎯 Potential Impact
+An unauthenticated attacker can upload malicious software bundles (DMGs, update patches) to the Aether release storage by simply using the authorization header `Bearer update_me_please`. If these bundles are distributed to end-users via the `/api/v1/aether/download` endpoints, this compromises the software supply chain, leading to mass compromise of client machines (e.g., executing malware on users' computers when they download an update).
+
+🛠️ Steps to Reproduce
+1. Ensure the `syscore` backend service is running without the `AETHER_UPLOAD_KEY` environment variable set.
+2. Construct a multipart POST request to `/api/v1/aether`.
+3. Set the header `Authorization: Bearer update_me_please`.
+4. Include valid form fields for a new version (e.g., `version`, `file`).
+5. Observe that the server returns a `201 CREATED` response and accepts the upload, bypassing intended authentication.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should fail securely if the expected environment variable is missing, either by refusing to start or by rejecting all uploads until the key is properly configured.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Performed a security audit of `syscore/src/server/aether.rs` acting as Sentinel. Identified two critical vulnerabilities:

1. Arbitrary File Write: `PathBuf::join` is used with unsanitized `filename` input from multipart form data, allowing absolute path injections.
2. Broken Auth: The `AETHER_UPLOAD_KEY` authentication relies on an `unwrap_or_else` fallback to a hardcoded default `"update_me_please"`.

Both vulnerabilities have been documented professionally following the Sentinel guidelines in `SECURITY_ISSUE.md` and the structural patterns have been logged in `.jules/sentinel.md`. No actual code changes were made to adhere to the boundary rules. Tests were run and remain green.

---
*PR created automatically by Jules for task [14266996399193098953](https://jules.google.com/task/14266996399193098953) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security audit documentation with guidance on hardcoded default credentials and authentication vulnerabilities.
  * New security documentation addressing authentication fallback risks, impact analysis, and secure remediation recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->