### PR TITLE
🛡️ Sentinel Audit: Hardcoded Secrets in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Fallback Secrets
+Vulnerability Pattern: Hardcoded default fallback secrets used in `unwrap_or_else` for environment variables.
+Systemic Cause: Developer convenience for local development led to a weak default credential (`update_me_please`) being compiled into the application's authentication logic.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,35 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Hardcoded Secrets: Default upload key allows unauthorized Aether version publication
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` falls back to a weak, hardcoded default key (`"update_me_please"`) if the `AETHER_UPLOAD_KEY` environment variable is not set.
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+This protects the `/api/v1/aether` file upload endpoint.
+
+🎯 Potential Impact
+An unauthenticated attacker can use the default credential `"update_me_please"` to bypass authorization and publish malicious Aether updates (binaries). This allows an attacker to push backdoored software to users, leading to widespread Remote Code Execution (RCE) on end-user machines.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Make a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Include necessary form fields (`version`, `description`, `changelog`) and a file payload.
+5. Observe that the server accepts the upload and publishes the new version.
+
+✅ Recommended Remediation
+Remove the weak fallback and fail securely if the expected environment variable is not configured.
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "AETHER_UPLOAD_KEY not configured".to_string()))?;
+```
+
+🔗 References
+- OWASP Hardcoded Secrets: https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password


### PR DESCRIPTION
As part of the Sentinel security audit:
- Identified a CRITICAL vulnerability (Broken Auth / Hardcoded Secrets) in `syscore/src/server/aether.rs`. The code uses a hardcoded fallback string `"update_me_please"` when `AETHER_UPLOAD_KEY` is not set, effectively opening the Aether update upload endpoint to unauthenticated attackers.
- Documented the finding in `SECURITY_ISSUE.md` strictly following the requested format (Severity, Description, Impact, Reproduction Steps, Remediation, References).
- Appended the architectural learning to `.jules/sentinel.md` as instructed.
- Strictly adhered to negative constraints: No code was modified, and no actual fixes were deployed (only the intel was documented for developers).

---
*PR created automatically by Jules for task [3829206282059618020](https://jules.google.com/task/3829206282059618020) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to identify and detail a critical hardcoded secrets vulnerability affecting the upload functionality, including impact assessment and remediation guidance to ensure secure credential handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->