### PR TITLE
Security Audit: Document Broken Auth in Aether Upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback in Aether Upload
+Vulnerability Pattern: Broken Auth via `unwrap_or_else` on environment variables for sensitive keys.
+Systemic Cause: The `upload_handler` falls back to a weak default string ("update_me_please") when the `AETHER_UPLOAD_KEY` environment variable is absent, prioritizing ease of local development over secure-by-default behavior in production.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default API key fallback in Aether version upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default credential fallback.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+If the `AETHER_UPLOAD_KEY` environment variable is not explicitly set in the deployment environment, the application falls back to a hardcoded, universally known string `"update_me_please"`.
+
+🎯 Potential Impact
+An unauthenticated external attacker can easily guess or discover this default credential and gain unauthorized access to the `/api/v1/aether` upload endpoint. This allows them to upload malicious versions of the Aether client or arbitrary files (especially when combined with the Arbitrary File Write vulnerability), leading to a supply chain attack or Remote Code Execution on the host system.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the request as authenticated, rather than returning a 401 Unauthorized response.
+
+✅ Recommended Remediation
+Remove the default fallback entirely and enforce secure configuration by failing to start or securely rejecting requests if the expected API key is not configured.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    // Ideally, the app should fail to boot if missing, but failing safely here works too.
+    (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "Server improperly configured: Missing AETHER_UPLOAD_KEY".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-10/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
I have completed the security audit as Sentinel.

Discovered a CRITICAL Broken Authentication vulnerability in `syscore/src/server/aether.rs` where `AETHER_UPLOAD_KEY` falls back to the weak default string `"update_me_please"`. 

I documented this finding in `SECURITY_ISSUE.md` and recorded the architectural learning in `.jules/sentinel.md`. All pre-commit testing has been run to ensure no regressions were caused by the audit. No source code was modified.

---
*PR created automatically by Jules for task [3278397750142791211](https://jules.google.com/task/3278397750142791211) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added security audit notes documenting potential vulnerabilities in file upload handling and authentication mechanisms
* Added security issue documentation detailing authentication weaknesses with remediation guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->