### PR TITLE
Sentinel Security Report: Broken Auth in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-19 - Broken Auth via Insecure Default Fallbacks
+Vulnerability Pattern: Hardcoded weak default credentials used when environment variables are missing (`unwrap_or_else`).
+Systemic Cause: Developers attempting to make local testing or initial setup easier by providing default fallback credentials instead of failing securely when required secrets are missing in production.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on `std::env::var` calls representing secrets or credentials, ensuring they fail securely rather than supplying weak defaults.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded weak default fallback for Aether Upload API Key
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+In `syscore/src/server/aether.rs`, the `upload_handler` function authenticates incoming requests by comparing the `Authorization` header against the `AETHER_UPLOAD_KEY` environment variable. However, if this environment variable is missing or not set, the application uses `unwrap_or_else` to fall back to a hardcoded, weak default credential: `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs (line 315)
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This insecure default guarantees that any deployment missing the `AETHER_UPLOAD_KEY` environment variable will be completely open to unauthorized uploads from anyone aware of the fallback key.
+
+🎯 Potential Impact
+An unauthenticated attacker can upload malicious payloads to the Aether update server using the default credentials (`Bearer update_me_please`). Coupled with other vulnerabilities (like Arbitrary File Write), this can lead to Remote Code Execution (RCE), arbitrary file overwrite, or distribution of malicious software updates to users.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the credentials and processes the upload.
+
+✅ Recommended Remediation
+Remove the `unwrap_or_else` fallback. The application should fail securely if the environment variable is not provided, either by rejecting requests or refusing to start up.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server is misconfigured: Missing AETHER_UPLOAD_KEY".to_string()))?;
+```
+Alternatively, validate the presence of the environment variable during application startup and panic if it's missing, ensuring the application never runs in an insecure state.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
I've completed my Sentinel mission by identifying a **CRITICAL** vulnerability in the backend.

### Findings:
1. **Vulnerability:** Broken Authentication / Hardcoded Fallback.
2. **Location:** `syscore/src/server/aether.rs` inside the `upload_handler` function.
3. **Issue:** The application expects an `AETHER_UPLOAD_KEY` environment variable. However, if this is missing, instead of failing securely, it uses `unwrap_or_else` to fall back to a hardcoded weak credential (`"update_me_please"`). 
4. **Impact:** Any deployment without the environment variable explicitly set is open to unauthorized file uploads, potentially leading to RCE if chained with the Arbitrary File Write vulnerability previously discovered in the same handler.

### Actions Taken:
*   I carefully verified the vulnerability by reading the source code via `grep` and inspecting the specific lines in `syscore/src/server/aether.rs` to satisfy the Groundedness Rule.
*   I appended a detailed, professionally formatted issue to `SECURITY_ISSUE.md` using the exact requested template without overwriting the previous critical finding.
*   I updated the `.jules/sentinel.md` journal to document this systemic issue regarding `unwrap_or_else` fallbacks.
*   I strictly followed boundaries: **no code was modified** and no branches/PRs were generated on the remote repo.
*   Relevant test suites (`cargo test` in `syscore` and `bun test` in `apps/web`) were run to ensure my file additions didn't disrupt anything.

---
*PR created automatically by Jules for task [3846601428160224757](https://jules.google.com/task/3846601428160224757) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit documentation with critical broken authentication vulnerability details and remediation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->