### PR TITLE
docs(security): report hardcoded auth secret in upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+
+## 2024-05-20 - Hardcoded Weak Default in Aether Upload Auth
+Vulnerability Pattern: Broken Auth / Hardcoded Secret via `unwrap_or_else` fallback.
+Systemic Cause: The system falls back to a weak, hardcoded default credential ("update_me_please") when the required environment variable (`AETHER_UPLOAD_KEY`) is missing. This bypasses the intended security requirement for a secret key.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely (e.g., panicking or returning an error) rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded Default Secret in Aether Upload Handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded fallback secret.
+At line 315, the application attempts to read the `AETHER_UPLOAD_KEY` environment variable. If the variable is not set, it uses `unwrap_or_else` to fallback to the hardcoded string `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that in environments where `AETHER_UPLOAD_KEY` is accidentally omitted, any user can authenticate and upload new versions by simply providing the `update_me_please` token.
+
+🎯 Potential Impact
+An unauthenticated attacker can publish malicious software updates to the Aether client update server. When clients check for updates, they could download and execute the malicious bundle, leading to widespread Remote Code Execution (RCE) on all connected client machines.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the authentication succeeds and the upload is processed.
+
+✅ Recommended Remediation
+Remove the fallback credential. The application should fail securely if a required security secret is missing. If `AETHER_UPLOAD_KEY` is not present, the application should return an internal server error or fail to start, rather than allowing trivial bypass.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "AETHER_UPLOAD_KEY not configured on server".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- Hardcoded Passwords/Credentials (CWE-798): https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Sentinel scan identified a CRITICAL Broken Authentication vulnerability in `syscore/src/server/aether.rs`. The `upload_handler` falls back to a weak hardcoded secret ("update_me_please") when `AETHER_UPLOAD_KEY` is omitted from the environment.

- Appended GitHub Issue format report to `SECURITY_ISSUE.md`.
- Updated `.jules/sentinel.md` journal with findings and systemic cause.
- No code modifications were made (Sentinel read-only enforcement).

---
*PR created automatically by Jules for task [10642172482426210795](https://jules.google.com/task/10642172482426210795) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security advisories documenting critical vulnerabilities affecting the file upload system. Identified issues include arbitrary file write risks and broken authentication mechanisms. Users are recommended to review the full security documentation and implement suggested mitigations immediately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->