### PR TITLE
Sentinel Audit: Report Broken Authentication Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-21 - Weak Default Credentials in Auth Fallbacks
+Vulnerability Pattern: Using `unwrap_or_else` or `unwrap_or` with hardcoded weak strings when environment variables for secrets/keys are missing.
+Systemic Cause: In `upload_handler`, `AETHER_UPLOAD_KEY` has a fallback of `update_me_please`. This creates a systemic broken authentication issue if the environment variable is not explicitly set in production.
+Auditor Note: Always check usages of `std::env::var` for sensitive keys. Ensure they fail securely (e.g., returning an error or panicking during startup) rather than providing a default weak string.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,46 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability. If the `AETHER_UPLOAD_KEY` environment variable is not set, it falls back to a weak, hardcoded default key (`"update_me_please"`).
+
+```rust
+// syscore/src/server/aether.rs, line 315
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that if the server is deployed without explicitly configuring this secret, anyone can authenticate and upload new versions of the software.
+
+🎯 Potential Impact
+An unauthenticated attacker can use the default credential `"update_me_please"` to bypass the authorization check. This allows them to upload malicious software updates (DMGs, bundles, or patches) to the Aether release channels, which could then be distributed to all end-users, leading to mass compromise (Supply Chain Attack).
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the Authorization header: `Authorization: Bearer update_me_please`.
+4. Observe that the request is accepted (Status 201 Created) instead of rejected (Status 401 Unauthorized).
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should fail securely if the expected authentication key is missing.
+Either panic on startup if the key is missing, or return an error/deny all requests if it is not configured.
+
+Example fix (failing securely at request time):
+```rust
+let expected_key = match std::env::var("AETHER_UPLOAD_KEY") {
+    Ok(key) => key,
+    Err(_) => {
+        tracing::error!("AETHER_UPLOAD_KEY is not set. Rejecting upload request.");
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, "Server authentication misconfigured".to_string()));
+    }
+};
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Documented a CRITICAL Broken Authentication vulnerability in `syscore/src/server/aether.rs` where the `upload_handler` falls back to a weak hardcoded API key (`update_me_please`). Added finding to `SECURITY_ISSUE.md` and updated `.jules/sentinel.md` journal. No source code modifications were made.

---
*PR created automatically by Jules for task [3631751266733910092](https://jules.google.com/task/3631751266733910092) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security audit documentation identifying vulnerabilities affecting file path handling during multipart uploads and authentication systems with unsecured default credential fallbacks
  * Provided detailed vulnerability descriptions, impact analysis, and remediation recommendations including secure failure mechanisms and proper environment variable validation practices

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->