### PR TITLE
docs(security): report aether upload handler vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Broken Auth in Aether Upload
+Vulnerability Pattern: Weak default credential fallback (`unwrap_or_else`) for `AETHER_UPLOAD_KEY`.
+Systemic Cause: The `upload_handler` provides a hardcoded string "update_me_please" if the environment variable `AETHER_UPLOAD_KEY` is not present, failing open rather than securely.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,45 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ HIGH Broken Auth: Weak Default Fallback in Aether Upload Key
+
+🚨 Severity
+HIGH
+
+💡 Description
+The `upload_handler` in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability. When validating the API key for uploading new Aether versions, it attempts to read the expected key from the `AETHER_UPLOAD_KEY` environment variable. However, if this environment variable is not set, it falls back to a weak, hardcoded default key (`"update_me_please"`).
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This ensures the upload endpoint is functional by default but exposes it to any attacker who discovers or guesses this fallback key. Since this endpoint handles file uploads (including binaries) that users will download, a compromised endpoint allows supply chain attacks.
+
+🎯 Potential Impact
+An unauthenticated attacker can use the default "update_me_please" key to bypass authorization and upload arbitrary files or malicious updates to the Aether channel. When combined with the Arbitrary File Write vulnerability, this allows immediate and remote exploitation to gain code execution or compromise the system, without needing to leak credentials.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the request is accepted (returning 201 Created or proceeding to further validation) instead of being rejected with 401 Unauthorized.
+
+✅ Recommended Remediation
+Fail securely if the `AETHER_UPLOAD_KEY` environment variable is not set. Do not provide a weak default fallback.
+
+Example fix:
+```rust
+let expected_key = match std::env::var("AETHER_UPLOAD_KEY") {
+    Ok(key) => key,
+    Err(_) => {
+        tracing::error!("AETHER_UPLOAD_KEY is not set. Rejecting upload.");
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration".to_string()));
+    }
+};
+```
+Alternatively, panic on startup if the required environment variables are not set.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
- Acted as Sentinel to perform a security audit on the aether upload handler.
- Discovered an Arbitrary File Write vulnerability due to unsanitized `PathBuf::join` with user-supplied filename.
- Discovered a Broken Auth vulnerability due to a weak default fallback key `update_me_please` when `AETHER_UPLOAD_KEY` is not present.
- Added detailed vulnerability reports to `SECURITY_ISSUE.md` using the provided GitHub Issue Template.
- Appended systemic learnings regarding weak default fallbacks to `.jules/sentinel.md`.
- No source code modifications were made.

---
*PR created automatically by Jules for task [14091543403388241720](https://jules.google.com/task/14091543403388241720) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to identify a high-severity broken authentication vulnerability in the upload service
  * Added audit entries documenting vulnerabilities related to credential management and path data handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->