### PR TITLE
doc: report critical broken auth in aether upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback in Aether Upload
+Vulnerability Pattern: Broken Auth via `unwrap_or_else` providing a weak default credential ("update_me_please") when `AETHER_UPLOAD_KEY` is missing.
+Systemic Cause: The developers attempted to make the application "fail-safe" or easier to run locally without configuring environment variables, inadvertently causing it to fail open in production if the environment variable is not explicitly set.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak Default Credential Fallback in Aether Upload
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default credential fallback. When reading the `AETHER_UPLOAD_KEY` environment variable, it uses `unwrap_or_else` to fallback to the hardcoded string `"update_me_please"`.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means if the production environment fails to set the `AETHER_UPLOAD_KEY`, the application fails open with a weak, predictable credential, rather than failing securely (e.g., denying all uploads).
+
+🎯 Potential Impact
+An unauthenticated attacker can trivially bypass the intended authentication mechanism by using the predictable bearer token `"update_me_please"`. Combined with the Arbitrary File Write vulnerability in the same endpoint, an attacker can fully compromise the system by uploading malicious payloads or overwriting critical system files without needing a valid administrative key.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Include the required multipart fields (`version`, `file`, etc.).
+5. Observe that the server accepts the upload with a `201 Created` response instead of a `401 Unauthorized`.
+
+✅ Recommended Remediation
+Remove the weak default fallback. If the environment variable is not set, the authentication check should securely fail.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Sentinel identified and reported a CRITICAL Broken Authentication vulnerability in the Aether upload handler (`syscore/src/server/aether.rs`) caused by a weak default fallback (`update_me_please`) when `AETHER_UPLOAD_KEY` is not present. The finding has been documented in `SECURITY_ISSUE.md` and the systemic cause logged in `.jules/sentinel.md` as per Sentinel boundaries.

---
*PR created automatically by Jules for task [14526218875847259749](https://jules.google.com/task/14526218875847259749) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security audit documentation with critical findings in the file upload system
  * Documented file path handling vulnerabilities that could enable arbitrary file writes
  * Documented authentication vulnerabilities from default credentials when configuration is missing
  * Included severity ratings, impact analysis, reproduction steps, and remediation recommendations with example fixes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->