### PR TITLE
🛡️ Sentinel Report: Broken Auth via weak default AETHER_UPLOAD_KEY

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback in Aether Upload
+Vulnerability Pattern: Broken Auth via weak default fallback on `unwrap_or_else` for `AETHER_UPLOAD_KEY`.
+Systemic Cause: The backend prioritizes keeping the service running over secure failure when a credential is missing, leading to a hardcoded weak secret (`"update_me_please"`) being used in production.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,42 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for AETHER_UPLOAD_KEY in upload_handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability. When validating the API Key provided in the `Authorization` header, the code checks against the `AETHER_UPLOAD_KEY` environment variable. If this variable is missing, it falls back to a hardcoded, weak default value (`"update_me_please"`):
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This allows an attacker to bypass authentication entirely if the deployment omits this environment variable, as they can simply provide `Bearer update_me_please`.
+
+🎯 Potential Impact
+An unauthorized attacker can trivially authenticate to the Aether release system and upload malicious binaries or patches. This can compromise the software supply chain, leading to malware distribution to all end-users downloading updates from this service.
+
+🛠️ Steps to Reproduce
+1. Deploy the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to `/api/v1/aether` with an upload payload.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the upload with a `201 Created` status instead of a `401 Unauthorized`.
+
+✅ Recommended Remediation
+The application should fail securely if a critical secret is missing. Remove the fallback value and return an internal server error or configuration error if the key is not set.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    tracing::error!("AETHER_UPLOAD_KEY is not configured");
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server authentication misconfigured".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
As Sentinel, I have identified a CRITICAL Broken Authentication vulnerability in `syscore/src/server/aether.rs`.

The `upload_handler` validates the API key from the `Authorization` header against the `AETHER_UPLOAD_KEY` environment variable. If the variable is not set, it explicitly falls back to a hardcoded, weak default value (`"update_me_please"`). This allows unauthorized attackers to trivially bypass authentication on the deployment by submitting a release with this weak credential, posing a severe risk to the software supply chain.

Changes made (Code intentionally unmodified as per constraints):
1. **Journal Updated:** Appended the architectural finding to `.jules/sentinel.md`, noting the systemic pattern of using `unwrap_or_else` on secrets without securely failing.
2. **Security Issue Created:** Appended a professional GitHub Issue template to `SECURITY_ISSUE.md` detailing the Broken Auth vulnerability, its impact, and recommended remediation strategies.

All testing and verification constraints have been met.

---
*PR created automatically by Jules for task [13102750420753368845](https://jules.google.com/task/13102750420753368845) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security advisories documenting identified vulnerabilities with remediation guidance to help users mitigate risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->