### PR TITLE
docs: Add Broken Auth security issue report

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-05-27 - Weak Default Secret Fallback
+Vulnerability Pattern: Broken Auth via weak default secret fallback (`unwrap_or_else`).
+Systemic Cause: The codebase uses `unwrap_or_else` on environment variables representing secrets (like `AETHER_UPLOAD_KEY`), falling back to a hardcoded string if the environment variable is missing. This prevents the application from failing securely when misconfigured.
+Auditor Note: Always audit uses of `unwrap_or_else` or `unwrap_or` on environment variables, especially those used for authentication, encryption, or API keys. Ensure that missing secrets result in a secure failure state rather than a weak default.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,47 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak Default Fallback for Aether API Key
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability due to a weak default fallback for the `AETHER_UPLOAD_KEY` environment variable. If the environment variable is not set, the code silently falls back to the hardcoded string "update_me_please" instead of returning an error or refusing to start.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+This means that if the service is deployed without the `AETHER_UPLOAD_KEY` explicitly configured, an attacker can use "update_me_please" as the bearer token to authenticate successfully.
+
+🎯 Potential Impact
+An unauthenticated attacker can trivially bypass authentication on the Aether version upload endpoint. Since this endpoint handles file uploads and overwrites, this vulnerability, especially when combined with the Arbitrary File Write vulnerability, allows an attacker to upload arbitrary files, overwrite system files, and potentially achieve Remote Code Execution (RCE).
+
+🛠️ Steps to Reproduce
+1. Ensure the `syscore` backend service is running without the `AETHER_UPLOAD_KEY` environment variable set.
+2. Send a POST request to the `/api/v1/aether` upload endpoint.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the request is authorized and processed.
+
+✅ Recommended Remediation
+Remove the `unwrap_or_else` fallback. The application should either fail to start if the required secret is missing, or the endpoint should consistently reject requests (e.g., returning 500 Internal Server Error) if the configuration is incomplete.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error: missing upload key".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-1188: Initialization of a Resource with an Insecure Default: https://cwe.mitre.org/data/definitions/1188.html


### PR DESCRIPTION
Sentinel scan identified a Critical Broken Auth vulnerability. The `upload_handler` in `syscore/src/server/aether.rs` uses `unwrap_or_else` to fallback to the hardcoded secret "update_me_please" if the `AETHER_UPLOAD_KEY` environment variable is not set. This allows unauthenticated users to upload versions trivially. Documented the issue in `SECURITY_ISSUE.md` and updated `.jules/sentinel.md` per strict auditor instructions. No code was modified.

---
*PR created automatically by Jules for task [5369868730131566135](https://jules.google.com/task/5369868730131566135) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation with critical authentication vulnerability details.
  * Added audit guidance and mitigation recommendations for identified security issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->