### PR TITLE
Sentinel Security Audit: Broken Auth in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-19 - Broken Auth via Environment Variable Fallback
+Vulnerability Pattern: Hardcoded default secret used when environment variable is missing.
+Systemic Cause: The `upload_handler` uses `unwrap_or_else` on `std::env::var("AETHER_UPLOAD_KEY")` to provide a weak default credential ("update_me_please") instead of failing securely when the secret is not configured.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials to ensure they do not introduce weak defaults.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,43 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for Aether upload authentication
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability due to a weak default credential fallback.
+When validating the Authorization header, the system checks against the `AETHER_UPLOAD_KEY` environment variable. If this variable is missing or not set in the environment, it uses `unwrap_or_else` to default to the hardcoded string `"update_me_please"`:
+
+```rust
+// syscore/src/server/aether.rs (line 315)
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that in any deployment where the administrator forgets to explicitly set the `AETHER_UPLOAD_KEY` environment variable, the upload endpoint is effectively protected by a publicly known, weak credential.
+
+🎯 Potential Impact
+An unauthenticated external attacker can bypass intended access controls by using the hardcoded Bearer token `"update_me_please"`. This grants full access to the Aether version upload functionality, allowing the attacker to publish malicious updates, overwrite legitimate software versions, or exploit other vulnerabilities in the upload pipeline.
+
+🛠️ Steps to Reproduce
+1. Deploy the `syscore` application without explicitly setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send an HTTP POST request to the `/api/v1/aether` upload endpoint.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the request passes the authentication check and proceeds to process the multipart payload, instead of returning a 401 Unauthorized response.
+
+✅ Recommended Remediation
+Fail securely if the required environment variable is missing, rather than falling back to a weak default.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This commit adds a security audit report for a critical Broken Auth vulnerability in the `syscore/src/server/aether.rs` `upload_handler` endpoint to `SECURITY_ISSUE.md`. It also records the vulnerability pattern in `.jules/sentinel.md` for future audits. No code was modified in this commit.

---
*PR created automatically by Jules for task [5250354334563255733](https://jules.google.com/task/5250354334563255733) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security audit notes with identified vulnerabilities and remediation guidance.
  * Added critical security issue report documenting an authentication vulnerability with reproduction steps and recommended fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->