### PR TITLE
docs: record broken auth vulnerability in aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-30 - Broken Auth in Aether File Upload
+Vulnerability Pattern: Weak default credential fallback via `unwrap_or_else` for `AETHER_UPLOAD_KEY`.
+Systemic Cause: The system falls back to a known, hardcoded weak credential ("update_me_please") when the environment variable is not present, rather than failing securely.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,44 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default credential fallback in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default fallback for the `AETHER_UPLOAD_KEY` environment variable.
+When validating the Authorization header, the code uses `unwrap_or_else` to supply a default value if the environment variable is missing:
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+If an administrator fails to properly set the `AETHER_UPLOAD_KEY` environment variable, the system silently falls back to accepting `"update_me_please"` as a valid bearer token.
+
+🎯 Potential Impact
+An unauthenticated attacker can trivially bypass the API key check by supplying `Authorization: Bearer update_me_please`. This grants them full access to upload new Aether software versions or patches, potentially distributing malware or malicious updates to all clients that pull from the update channel. Coupled with the Arbitrary File Write vulnerability, this allows complete system compromise.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Include necessary form fields (`version`, `file`, etc.).
+5. Send the request.
+6. Observe that the request is authorized and the upload succeeds, returning a `201 CREATED` status instead of `401 UNAUTHORIZED`.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The system should fail securely (fail-closed) if the required secret is not configured.
+1. Return a `500 Internal Server Error` or log a critical error and panic at startup if the `AETHER_UPLOAD_KEY` is not present.
+2. Alternatively, return `401 UNAUTHORIZED` if the environment variable is missing when the handler is called.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: missing upload key".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-1188: Initialization of a Resource with an Insecure Default: https://cwe.mitre.org/data/definitions/1188.html


### PR DESCRIPTION
Appended a new entry to `.jules/sentinel.md` documenting the Broken Auth vulnerability caused by using `unwrap_or_else` with a weak fallback credential. Added a detailed GitHub Issue report for the vulnerability to `SECURITY_ISSUE.md`.

---
*PR created automatically by Jules for task [11468544703129770672](https://jules.google.com/task/11468544703129770672) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security audit documentation to record identified vulnerabilities in file upload processing and authentication handling.
  * Added critical security advisory documenting risks from weak default credentials and file path override issues.
  * Included remediation guidance and secure implementation examples for addressing identified vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vaiditya2207/OKernel/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->