### PR TITLE
docs: Document broken auth vulnerability in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback in Aether Upload
+Vulnerability Pattern: Broken Auth via fallback to weak, hardcoded default credential when environment variable is missing.
+Systemic Cause: The `upload_handler` uses `unwrap_or_else` to fallback to "update_me_please" if `AETHER_UPLOAD_KEY` is not set in the environment, bypassing secure authentication.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ [CRITICAL] Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak, hardcoded default API key.
+When attempting to retrieve the expected upload key from the environment variable `AETHER_UPLOAD_KEY`, the code uses `unwrap_or_else` to fall back to the string `"update_me_please"` if the environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This ensures that if a system administrator forgets to set the `AETHER_UPLOAD_KEY` environment variable or misconfigures the deployment, the server will silently fall back to accepting `"update_me_please"` as a valid bearer token for authentication.
+
+🎯 Potential Impact
+An unauthenticated attacker can trivially bypass authentication on the `/api/v1/aether` upload endpoint by providing the `Authorization: Bearer update_me_please` header. This allows unauthorized users to publish arbitrary files, bundles, and metadata, poisoning the update distribution channel.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send an HTTP POST request to `/api/v1/aether`.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the authentication and processes the multipart upload, rather than returning a `401 UNAUTHORIZED`.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should fail securely (fail-closed) if the required secret is not provided in the environment.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: missing API key".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This commit adds a detailed security vulnerability report to `SECURITY_ISSUE.md` detailing the broken authentication vulnerability found in `syscore/src/server/aether.rs` where `upload_handler` falls back to a hardcoded default credential if the `AETHER_UPLOAD_KEY` environment variable is not set. It also logs this architectural finding in `.jules/sentinel.md` as per Sentinel's constraints, without modifying the source code.

---
*PR created automatically by Jules for task [2087285229215044997](https://jules.google.com/task/2087285229215044997) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security advisories documenting vulnerabilities related to file path handling and API authentication, including remediation guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->