### PR TITLE
🛡️ [CRITICAL] Broken Auth: Hardcoded default API key in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-06-01 - Hardcoded Fallback Credential in Aether Server
+Vulnerability Pattern: Broken Auth via weak default fallback credential (`unwrap_or_else` on environment variables).
+Systemic Cause: In `syscore/src/server/aether.rs`, the `upload_handler` uses `unwrap_or_else` on an environment variable (`AETHER_UPLOAD_KEY`) representing a secret. This supplies a weak default ("update_me_please") instead of failing securely when the environment is misconfigured.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials in Rust, ensuring they fail securely rather than supplying weak defaults.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,38 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ [CRITICAL] Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability because it falls back to a weak, hardcoded default credential ("update_me_please") when the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This allows any attacker to bypass authentication on a sensitive file upload endpoint if the service is deployed without the environment variable explicitly configured.
+
+🎯 Potential Impact
+An unauthorized user can upload arbitrary Aether versions and metadata to the server. Combined with the Arbitrary File Write vulnerability in the same handler, this easily leads to complete unauthenticated Remote Code Execution (RCE) on the server.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting `AETHER_UPLOAD_KEY`.
+2. Make a POST request to `/api/v1/aether` (the upload endpoint).
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the request is accepted instead of returning a 401 Unauthorized error.
+
+✅ Recommended Remediation
+Do not provide a default fallback for sensitive credentials. If the environment variable is missing, the service should fail securely by returning a configuration error or crashing on startup.
+Instead of using `unwrap_or_else`, use `Result` handling, or crash on startup if missing.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").expect("AETHER_UPLOAD_KEY environment variable must be set");
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/


### PR DESCRIPTION
Identified and documented a Broken Auth vulnerability in `syscore/src/server/aether.rs` where `upload_handler` uses a weak fallback credential. Documented in `SECURITY_ISSUE.md` and `.jules/sentinel.md`. Code changes strictly limited to security documentation as per Sentinel rules.

---
*PR created automatically by Jules for task [5999781064910529923](https://jules.google.com/task/5999781064910529923) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal security documentation and audit updates with no user-facing changes. Updates include security advisories and audit records related to infrastructure assessment and vulnerability tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->