### PR TITLE
docs: Add security report for Broken Auth in aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Broken Auth via Environment Variable Fallback
+Vulnerability Pattern: Weak default credential ('update_me_please') used when `AETHER_UPLOAD_KEY` is missing in `upload_handler`.
+Systemic Cause: The use of `unwrap_or_else` on `std::env::var` for critical secrets provides an unsafe fallback instead of failing securely when the environment variable is absent.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials across the codebase.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,43 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for AETHER_UPLOAD_KEY allows unauthorized uploads
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability. When validating the `Authorization` header, it fetches the expected API key from the `AETHER_UPLOAD_KEY` environment variable. However, if this environment variable is not set, it falls back to a hardcoded, weak default value: `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that in environments where the key is accidentally omitted or misconfigured, any user can authenticate to the upload endpoint using the token `"update_me_please"`.
+
+🎯 Potential Impact
+An unauthenticated attacker can upload arbitrary files or malicious software updates to the Aether backend by supplying the `"update_me_please"` Bearer token. This allows them to distribute malware to end users or, combined with other vulnerabilities (such as Arbitrary File Write), execute code on the server.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to `/api/v1/aether` to upload a file.
+3. Provide the header `Authorization: Bearer update_me_please`.
+4. Observe that the request is authorized and processed successfully instead of being rejected.
+
+✅ Recommended Remediation
+Do not provide a fallback for critical security credentials. If the environment variable is missing, the application should either fail to start or safely reject all requests that require it.
+
+Change the code to handle the missing environment variable securely, for example:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    tracing::error!("AETHER_UPLOAD_KEY is not set!");
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
As Sentinel, I successfully identified and reported a CRITICAL Broken Authentication vulnerability in the Aether upload handler (`syscore/src/server/aether.rs`).

The `upload_handler` falls back to a weak, hardcoded default credential (`"update_me_please"`) if the `AETHER_UPLOAD_KEY` environment variable is not present. This allows unauthenticated attackers to bypass authentication entirely if the environment is misconfigured.

I have:
1. Created an architectural learning entry in `.jules/sentinel.md` documenting this systemic fallback issue.
2. Appended a fully formatted GitHub issue report to `SECURITY_ISSUE.md` describing the vulnerability, potential impact, steps to reproduce, and recommended remediation.
3. Strictly adhered to the rules of not modifying the source code and formatting the output as requested.

---
*PR created automatically by Jules for task [9880657676737627003](https://jules.google.com/task/9880657676737627003) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Security audit notes published documenting critical vulnerabilities in authentication and file path handling, including remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->