### PR TITLE
docs: Add Sentinel report for Broken Auth in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Default Credentials in Authentication
+Vulnerability Pattern: Broken Auth via weak default fallback for API Key (`unwrap_or_else(|_| "update_me_please".to_string())`).
+Systemic Cause: The `upload_handler` attempts to be robust by providing a fallback if the environment variable `AETHER_UPLOAD_KEY` is not set, unintentionally hardcoding a highly guessable credential in production code.
+Auditor Note: Always audit `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,37 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default fallback for AETHER_UPLOAD_KEY
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default fallback credential. If the `AETHER_UPLOAD_KEY` environment variable is not set, the application falls back to a hardcoded string `"update_me_please"`.
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+This means any deployment missing this environment variable will be completely open to unauthorized access using a trivial, universally known password.
+
+🎯 Potential Impact
+An unauthenticated attacker can supply the default credential (`Bearer update_me_please`) to gain full administrative access to the `upload_handler`. This allows the attacker to upload malicious payloads, manipulate release versions, and potentially distribute malware to all users of the Aether application, compromising the entire software supply chain.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Include a valid multipart form payload for a new version upload.
+5. Observe that the server accepts the upload and returns a `201 Created` status, successfully bypassing intended authentication.
+
+✅ Recommended Remediation
+Do not provide default fallback values for security-critical secrets. Ensure the application fails to start or the endpoint returns an error securely if the secret is missing.
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
This PR adds a security audit report identifying a CRITICAL Broken Authentication vulnerability in the Aether version upload handler. 

**Findings:**
- `upload_handler` uses a weak default fallback (`update_me_please`) for `AETHER_UPLOAD_KEY`.
- Documented the vulnerability and remediation steps in `SECURITY_ISSUE.md`.
- Logged the architectural learning and systemic cause in `.jules/sentinel.md`.

*Note: As Sentinel, no code changes have been made. This PR only provides the required intelligence and documentation for the development team to act on.*

---
*PR created automatically by Jules for task [8111526905244242673](https://jules.google.com/task/8111526905244242673) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to address a critical authentication vulnerability involving hardcoded default credentials
  * Added sentinel findings documenting insecure credential fallback behavior when environment variables are missing
  * Included impact assessment, reproduction steps, and remediation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->