### PR TITLE
docs: report Broken Auth in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-06-07 - Weak Default Fallback in Aether Upload Auth
+Vulnerability Pattern: Broken Auth via weak default credential in `unwrap_or_else` on environment variable.
+Systemic Cause: The application uses `unwrap_or_else` on `std::env::var` for the `AETHER_UPLOAD_KEY` secret, supplying a hardcoded fallback (`"update_me_please"`) instead of failing securely when the environment variable is missing. This violates the Fail-Safe Default principle.
+Auditor Note: Always check for `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials to ensure they do not introduce weak defaults.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,49 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for Aether upload authentication
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to an insecure fallback for the `AETHER_UPLOAD_KEY` environment variable. When the environment variable is missing, the application defaults to the weak, hardcoded credential `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+If a server administrator forgets to set `AETHER_UPLOAD_KEY`, the upload endpoint becomes accessible to anyone who knows or guesses this hardcoded string.
+
+🎯 Potential Impact
+An unauthorized attacker can bypass authentication by using the default token. Since the endpoint handles file uploads (and is also vulnerable to Arbitrary File Write), this can lead to remote code execution (RCE) and full compromise of the backend service and host system.
+
+🛠️ Steps to Reproduce
+1. Ensure the `syscore` backend service is running in an environment where `AETHER_UPLOAD_KEY` is not set.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Set the authorization header: `Authorization: Bearer update_me_please`.
+4. Observe that the request is accepted and the file upload proceeds successfully, instead of rejecting the request with a `401 UNAUTHORIZED`.
+
+✅ Recommended Remediation
+Remove the insecure default fallback. If the required environment variable for authentication is not set, the application should fail securely. This can be done by returning an error at runtime or, ideally, failing to start the application.
+
+Example fix for runtime enforcement:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- Fail-Safe Defaults Principle: https://owasp.org/www-community/Fail_safely


### PR DESCRIPTION
Identified and reported a Critical Broken Authentication vulnerability in the Aether upload handler (`syscore/src/server/aether.rs`). The `upload_handler` falls back to a hardcoded default credential ("update_me_please") when the `AETHER_UPLOAD_KEY` environment variable is not set, allowing unauthorized users to bypass authentication and upload files. Documented the issue in `SECURITY_ISSUE.md` and added architectural learnings to the Sentinel journal (`.jules/sentinel.md`).

---
*PR created automatically by Jules for task [15813895885437086562](https://jules.google.com/task/15813895885437086562) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit documentation with critical vulnerability entries documenting authentication weaknesses in the upload endpoint.
  * Enhanced security advisory with findings regarding insecure default credentials and file path handling risks, including remediation recommendations and compliance references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->