### PR TITLE
Security Audit: Broken Auth in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-06-08 - Weak Default Credentials in Aether Upload Auth
+Vulnerability Pattern: Broken Auth via weak default fallback on missing environment variables.
+Systemic Cause: The `upload_handler` uses `unwrap_or_else` on `std::env::var("AETHER_UPLOAD_KEY")` to supply a weak default credential ("update_me_please") instead of securely failing when the key is missing.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials to ensure they fail securely.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,36 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak Default Fallback for Aether Upload Key
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability because it defaults to a known weak API key if the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+If the deployment environment fails to provide the `AETHER_UPLOAD_KEY`, the system quietly degrades to using "update_me_please".
+
+🎯 Potential Impact
+Any unauthorized user who knows the default credential can upload malicious bundles to the Aether update server. This allows attackers to distribute compromised software updates to all clients, leading to a massive supply chain attack.
+
+🛠️ Steps to Reproduce
+1. Deploy the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Provide the default authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the upload, demonstrating the default credential is active.
+
+✅ Recommended Remediation
+Do not provide weak fallbacks for security credentials. If a required secret is missing, the application should fail securely (e.g., return a 500 error or refuse to start).
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error: Missing API Key".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/


### PR DESCRIPTION
Added a new security report to SECURITY_ISSUE.md detailing a CRITICAL Broken Auth vulnerability in `syscore/src/server/aether.rs`. Also updated the Sentinel journal in `.jules/sentinel.md` with architectural learnings. No source code was modified.

---
*PR created automatically by Jules for task [2967581717567079907](https://jules.google.com/task/2967581717567079907) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * **Critical Authentication Weakness**: Upload endpoint documented to contain authentication vulnerability allowing unauthorized access when credentials are not properly configured
  * **File Write Vulnerability**: Multipart upload processing documented to have arbitrary file write vulnerability that could enable path traversal attacks
  * Security audit findings and remediation guidance available in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->