### PR TITLE
🛡️ CRITICAL Broken Auth: Weak default fallback credential in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Fallback Credentials in Aether Auth
+Vulnerability Pattern: Broken Auth via weak default fallback credentials.
+Systemic Cause: The use of `unwrap_or_else` on environment variables that represent secrets (`AETHER_UPLOAD_KEY`), providing a weak default instead of failing securely.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,40 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback credential in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` implements a fallback default credential `"update_me_please"` for the `AETHER_UPLOAD_KEY` environment variable.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+If the environment variable is not explicitly set in the production environment, the server will silently fall back to this weak, hardcoded secret. This allows any attacker who knows this common default to bypass authentication on the critical software update/upload endpoint.
+
+🎯 Potential Impact
+An unauthenticated attacker could upload malicious binaries, bundles, or patches to the Aether update server by authenticating with the `update_me_please` credential. When clients download the latest version, they will receive the attacker's malicious payload, leading to a widespread supply chain attack and remote code execution on all client machines.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to `/api/v1/aether` with the header `Authorization: Bearer update_me_please`.
+3. Include the necessary multipart fields (e.g., `version`, `file`).
+4. Observe that the server responds with HTTP 201 Created and accepts the upload, bypassing secure authentication.
+
+✅ Recommended Remediation
+Remove the `.unwrap_or_else` fallback. The application should fail securely if the `AETHER_UPLOAD_KEY` is not provided.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error: Missing API key".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
As Sentinel, investigated the codebase and found a critical Broken Authentication vulnerability in `syscore/src/server/aether.rs`. 
The `upload_handler` implements a weak fallback default credential (`update_me_please`) if the `AETHER_UPLOAD_KEY` environment variable is missing, allowing unauthenticated attackers to upload malicious updates.

Changes made:
- Appended a formatted GitHub Issue to `SECURITY_ISSUE.md` describing the vulnerability, impact, and remediation without modifying actual source code.
- Recorded the architectural learning regarding `unwrap_or_else` on secret environment variables in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7449399505606510310](https://jules.google.com/task/7449399505606510310) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability audit documentation detailing critical broken authentication from weak default credentials and arbitrary file write risks from path injection in file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->