### PR TITLE
Document Broken Auth vulnerability in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-19 - Hardcoded Default Credential in Aether File Upload
+Vulnerability Pattern: Broken Auth via weak default fallback (`update_me_please`) when `AETHER_UPLOAD_KEY` environment variable is missing.
+Systemic Cause: The `upload_handler` relies on `unwrap_or_else` to provide a hardcoded secret fallback, effectively disabling authentication for sensitive endpoints if the environment is misconfigured.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,48 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded default API key.
+When checking the authorization header, the code attempts to read the `AETHER_UPLOAD_KEY` environment variable. If it is missing, it falls back to the weak default credential `"update_me_please"` using `unwrap_or_else`:
+
+```rust
+// syscore/src/server/aether.rs
+    let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+    if auth_header != Some(&expected_key) {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+    }
+```
+
+This effectively bypasses authentication if the deployment environment omits the `AETHER_UPLOAD_KEY` variable.
+
+🎯 Potential Impact
+An unauthenticated attacker can use the publicly known `"update_me_please"` credential to upload malicious files, create unauthorized releases, or overwrite existing system files. This leads to unauthorized data modification and potential Remote Code Execution.
+
+🛠️ Steps to Reproduce
+1. Ensure the `syscore` backend service is running without the `AETHER_UPLOAD_KEY` environment variable set.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Include the default authorization header: `Authorization: Bearer update_me_please`.
+4. Send the request with valid multipart fields.
+5. Observe that the server accepts the upload and returns a `201 CREATED` status instead of `401 UNAUTHORIZED`.
+
+✅ Recommended Remediation
+Remove the hardcoded fallback credential. The application should fail securely if a required secret is missing from the environment.
+If the variable is missing, either log a startup error and terminate the application, or return a consistent `500 INTERNAL SERVER ERROR` or `401 UNAUTHORIZED` without falling back to a known weak key.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: missing API key".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
As requested, Sentinel has documented a CRITICAL vulnerability regarding Broken Authentication in the Aether upload handler. The issue stems from the use of a hardcoded fallback credential when the `AETHER_UPLOAD_KEY` environment variable is missing.

The finding has been appended to `SECURITY_ISSUE.md` using the exact requested GitHub Issue format, and `.jules/sentinel.md` has been updated with the corresponding architectural learning. No codebase files were modified. All tests passed correctly.

---
*PR created automatically by Jules for task [11622912916539697397](https://jules.google.com/task/11622912916539697397) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security audit documentation to include additional findings regarding infrastructure vulnerabilities and secure coding best practices.
  * Updated critical security issue tracking with detailed findings, impact assessments, and remediation guidance for configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->