### PR TITLE
docs(security): Report weak default credential vulnerability in Aether upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-06-11 - Weak Default Credentials in Aether File Upload
+Vulnerability Pattern: Hardcoded/Weak default secrets in authentication checks.
+Systemic Cause: The `upload_handler` retrieves the `AETHER_UPLOAD_KEY` environment variable but uses `unwrap_or_else` to fallback to `"update_me_please"`. This leads to a known weak credential bypassing authentication if the environment variable is not explicitly set.
+Auditor Note: Always check for `unwrap_or` or `unwrap_or_else` applied to environment variables representing credentials or secrets to ensure they fail securely instead of falling back to default values.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,42 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default credential fallback in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default credential fallback. When checking the authorization header against the expected API key, the code attempts to read the `AETHER_UPLOAD_KEY` environment variable. However, if this environment variable is missing, it falls back to a hardcoded default string `"update_me_please"` using `unwrap_or_else`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that in environments where `AETHER_UPLOAD_KEY` is not explicitly configured, any attacker who knows or guesses this default string can bypass authentication completely.
+
+🎯 Potential Impact
+An unauthorized, remote attacker can authenticate using the default Bearer token `"update_me_please"`. Once authenticated, the attacker can upload malicious bundles, tampered updates, or arbitrary files to the Aether release system, leading to malware distribution to end-users or complete system compromise.
+
+🛠️ Steps to Reproduce
+1. Ensure the `AETHER_UPLOAD_KEY` environment variable is not set on the host running the server.
+2. Send a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Include valid form data for the upload (e.g., version, channel, file).
+5. Observe that the server returns a `201 Created` status code, confirming the malicious upload was accepted.
+
+✅ Recommended Remediation
+Remove the default fallback and fail securely if the expected environment variable is not present. This ensures that the system refuses to accept uploads until properly configured.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: missing upload key".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-1188: Initialization of a Resource with an Insecure Default: https://cwe.mitre.org/data/definitions/1188.html


### PR DESCRIPTION
Acted as Sentinel to document a CRITICAL security vulnerability without modifying code.

**Findings:**
- Discovered a weak default credential fallback (`unwrap_or_else(|_| "update_me_please".to_string())`) in `syscore/src/server/aether.rs` during file upload authorization check.

**Actions:**
- Created a new journal entry in `.jules/sentinel.md` documenting the systemic pattern.
- Appended a formatted GitHub issue report to `SECURITY_ISSUE.md` detailing the vulnerability, impact, reproduction steps, and remediation.

**Verification:**
- Ran `cargo test` in `syscore` to ensure no breakages.
- Pre-commit code review passed.

---
*PR created automatically by Jules for task [12696871644021565487](https://jules.google.com/task/12696871644021565487) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security guidance with new audit notes emphasizing secure credential management practices and fail-safe approaches.
  * Added references for authentication security best practices and vulnerability prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->