### PR TITLE
docs: Report Broken Auth Vulnerability in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback
+Vulnerability Pattern: Hardcoded Secrets / Weak Default Fallback using `unwrap_or_else` for environment variables.
+Systemic Cause: In `syscore/src/server/aether.rs`, the server falls back to a weak default credential ('update_me_please') if the `AETHER_UPLOAD_KEY` environment variable is not set, bypassing standard security practices of failing securely.
+Auditor Note: Always check usages of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,53 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+---
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback credential in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a severe Broken Authentication vulnerability. When validating the Authorization header, the server attempts to read the expected API key from the `AETHER_UPLOAD_KEY` environment variable. However, it uses `unwrap_or_else` to fall back to a hardcoded, weak default credential (`"update_me_please"`) if the environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+// 1. Auth Check
+let auth_header = headers.get("Authorization")
+    .and_then(|h| h.to_str().ok())
+    .and_then(|h| h.strip_prefix("Bearer "));
+
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+
+if auth_header != Some(&expected_key) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+If the `AETHER_UPLOAD_KEY` is accidentally omitted during deployment, any unauthenticated attacker can upload malicious software updates by simply using the well-known string `"update_me_please"` as the Bearer token.
+
+🎯 Potential Impact
+An attacker can authenticate to the restricted `/api/v1/aether` endpoint and push malicious application updates (bundles and patches) to clients. This allows for massive supply chain attacks where legitimate users automatically download and execute attacker-controlled payloads on their machines, leading to widespread compromise.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service in an environment where `AETHER_UPLOAD_KEY` is not set.
+2. Construct a multipart POST request to the `/api/v1/aether` endpoint.
+3. Set the `Authorization` header to `Bearer update_me_please`.
+4. Send the request with required multipart fields (`version`, `file`, etc.).
+5. Observe that the server returns a `201 CREATED` response instead of `401 UNAUTHORIZED`, successfully publishing the malicious update.
+
+✅ Recommended Remediation
+Remove the weak default fallback credential. The application should fail securely (e.g., fail to start or reject all upload requests) if the required environment variable is missing.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
+```
+Alternatively, read the configuration once at startup and panic if the secret is missing, rather than evaluating it per request.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Appended a new CRITICAL finding to SECURITY_ISSUE.md detailing a Broken Authentication vulnerability due to a weak default credential fallback (`unwrap_or_else("update_me_please")`) in the `AETHER_UPLOAD_KEY` validation of the `upload_handler` in `syscore/src/server/aether.rs`. Added the corresponding learning to `.jules/sentinel.md`. No code modifications were made.

---
*PR created automatically by Jules for task [18011899708516795686](https://jules.google.com/task/18011899708516795686) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Documented two critical vulnerabilities: arbitrary file write risk through path injection and weak credential fallback when environment-based authentication is unset.
  * Added security advisory with impact assessment, reproduction steps, and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->