### PR TITLE
docs(security): Report broken auth vulnerability in aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Weak Default Credential in Aether Upload
+Vulnerability Pattern: Broken Auth via weak default fallback credential (`update_me_please`).
+Systemic Cause: The `upload_handler` attempts to read the `AETHER_UPLOAD_KEY` environment variable but uses `unwrap_or_else` to fallback to a widely known, weak default password instead of failing securely when the secret is missing.
+Auditor Note: Always check usages of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,39 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak Default Fallback Credential in Aether Upload Handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Auth vulnerability because it falls back to a weak, hardcoded default credential if the `AETHER_UPLOAD_KEY` environment variable is not set.
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+This means that if an administrator forgets to set the environment variable, the upload endpoint is completely open to anyone who provides the bearer token `update_me_please`.
+
+🎯 Potential Impact
+An unauthenticated attacker can use the default credential to upload malicious application bundles or overwrite existing versions. This could allow an attacker to distribute backdoored application updates to users, leading to wide-scale compromise.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to `/api/v1/aether` to upload a new version.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the request is accepted and the file is written, rather than returning a `401 UNAUTHORIZED`.
+
+✅ Recommended Remediation
+Remove the `unwrap_or_else` fallback. The application should fail to start if the required secret is not provided, or the handler should explicitly fail the request if the secret is missing.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    tracing::error!("AETHER_UPLOAD_KEY not set. Refusing uploads.");
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration".to_string())
+})?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-10/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Documented a Broken Auth vulnerability in `syscore/src/server/aether.rs` where `upload_handler` falls back to a weak default credential if `AETHER_UPLOAD_KEY` is not set.

Added findings to `SECURITY_ISSUE.md` and `.jules/sentinel.md`. No code was modified.

---
*PR created automatically by Jules for task [15475784142285478346](https://jules.google.com/task/15475784142285478346) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated security audit entries documenting identified risks and findings.
  - Added critical security advisory with remediation steps and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->