### PR TITLE
🛡️ Add CRITICAL Broken Auth vulnerability to SECURITY_ISSUE.md

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Fallback Credentials in Auth
+Vulnerability Pattern: Broken Auth via weak default fallback (`unwrap_or_else`) on environment variables for sensitive keys.
+Systemic Cause: The codebase attempts to provide developer convenience by supplying a default fallback if environment variables are missing, leading to critically weak authentication in production if not properly configured.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,37 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded weak fallback credential in Aether upload_handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded fallback credential. When the environment variable `AETHER_UPLOAD_KEY` is not present, the system defaults to using the weak static key `"update_me_please"`.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This allows any unauthenticated attacker who knows this default key to bypass authentication and upload files to the server.
+
+🎯 Potential Impact
+An unauthenticated attacker can upload malicious bundles, patches, or files to the server. Combined with the arbitrary file write vulnerability, this leads to an unauthenticated Remote Code Execution (RCE) and full server compromise. Even without the file write vulnerability, it allows unauthorized distribution of malicious software updates to clients.
+
+🛠️ Steps to Reproduce
+1. Ensure the `syscore` backend service is running without the `AETHER_UPLOAD_KEY` environment variable set.
+2. Send a POST request to `/api/v1/aether` with the header `Authorization: Bearer update_me_please`.
+3. Include valid multipart form data (e.g., `version`, `file`).
+4. Observe that the server accepts the upload and returns a 201 Created response.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should securely fail or refuse to start if critical secrets like `AETHER_UPLOAD_KEY` are not provided in the environment.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .expect("FATAL: AETHER_UPLOAD_KEY environment variable is missing.");
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
I have successfully completed the security audit as Sentinel.

1.  **Vulnerability Found**: I discovered a CRITICAL Broken Authentication vulnerability in the Aether `upload_handler` (`syscore/src/server/aether.rs`). The handler uses `unwrap_or_else` on the `AETHER_UPLOAD_KEY` environment variable, defaulting to a weak static key `"update_me_please"` if not present. This allows unauthenticated attackers to bypass authentication and upload files.
2.  **Documentation Update**: I appended a detailed, professionally formatted GitHub Issue to `SECURITY_ISSUE.md` describing the vulnerability, its impact (potential unauthenticated RCE when combined with the file write vulnerability), steps to reproduce, and recommended remediation. I was careful to append to the file to preserve the existing Arbitrary File Write report.
3.  **Journal Entry**: I updated `.jules/sentinel.md` with an architectural learning about the systemic cause of this pattern (using weak defaults for missing environment variables intended for developer convenience).
4.  **Verification**: I verified the contents of both files using `cat` and successfully ran the test suites (`cargo test` and `bun test`) to ensure no code was broken, satisfying the completeness rule. As instructed for the Sentinel role, I did not modify the source code to fix the vulnerability.

---
*PR created automatically by Jules for task [8204999213062083685](https://jules.google.com/task/8204999213062083685) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new security notes and vulnerability write-ups with clearer structure and auditor comments.
  * Expanded guidance for a critical authentication issue, including safer handling recommendations and reference material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->