### PR TITLE
Report CRITICAL Broken Auth Vulnerability in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Weak Default Credential Fallback
+Vulnerability Pattern: Hardcoded default fallback for secret environment variables using `unwrap_or_else`.
+Systemic Cause: The developer used `unwrap_or_else` on `std::env::var` for the `AETHER_UPLOAD_KEY` to prevent application crashes or for convenience during local testing, but accidentally left this insecure fallback in production code.
+Auditor Note: Always check for `unwrap_or_else` and `unwrap_or` calls on environment variables representing API keys, passwords, or secrets. Ensure they fail securely rather than supplying weak default credentials.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,45 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Weak default fallback for AETHER_UPLOAD_KEY
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` falls back to a hardcoded, weak default credential if the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+This is a severe security flaw. If the application is deployed without `AETHER_UPLOAD_KEY` properly configured, any unauthenticated attacker can use the default bearer token `"update_me_please"` to authenticate and upload potentially malicious versions.
+
+🎯 Potential Impact
+An attacker can bypass authentication on the Aether version upload endpoint. This allows them to publish malicious updates, overwrite existing binaries (especially if combined with other vulnerabilities like path traversal), or poison the update channel, leading to widespread compromise of clients receiving the updates.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to the `/api/v1/aether` endpoint.
+3. Provide the authentication header: `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the authentication and processes the upload request (e.g., returning 201 Created or a validation error for missing fields, but not 401 Unauthorized).
+
+✅ Recommended Remediation
+Remove the fallback credential. The service should securely fail or reject authentication if the expected environment variable is missing.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| {
+    tracing::error!("AETHER_UPLOAD_KEY is not set. Refusing authentication.");
+    (StatusCode::INTERNAL_SERVER_ERROR, "Server authentication misconfigured".to_string())
+})?;
+
+if auth_header != Some(expected_key.as_str()) {
+    return Err((StatusCode::UNAUTHORIZED, "Invalid or missing API Key".to_string()));
+}
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This branch documents a critical security vulnerability found during a Sentinel audit: a broken authentication issue in the `upload_handler` (`syscore/src/server/aether.rs`) where the API falls back to a weak default credential (`update_me_please`) when `AETHER_UPLOAD_KEY` is absent. The finding is logged as a GitHub Issue in `SECURITY_ISSUE.md` and the structural pattern is recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3925181581533437170](https://jules.google.com/task/3925181581533437170) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security note describing a critical authentication weakness and its potential impact on unauthorized uploads.
  * Expanded the audit log with an additional security finding related to weak default credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->