### PR TITLE
Sentinel Audit: Broken Authentication in Aether Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2026-06-28 - Weak Default Credential Fallback in Aether File Upload
+Vulnerability Pattern: Broken Auth via hardcoded weak default credential fallback.
+Systemic Cause: The `upload_handler` in `syscore/src/server/aether.rs` uses `std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string())`. If the environment variable is missing (which might easily happen in dev/test or misconfigured production), the system allows authentication using a known, hardcoded string.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,43 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded weak default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded fallback value for the API key.
+When checking the authorization header against the expected key, the code uses `unwrap_or_else` on the environment variable lookup:
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+If the `AETHER_UPLOAD_KEY` environment variable is not explicitly set (e.g., due to misconfiguration or missing `.env` files in production/staging environments), the application will fall back to the known string `"update_me_please"`. This creates a backdoor that an attacker can exploit to bypass authentication.
+
+🎯 Potential Impact
+An unauthorized attacker can trivially bypass the authentication mechanism by using the hardcoded Bearer token (`update_me_please`). This grants them full access to the upload endpoint, enabling them to upload arbitrary Aether versions, overwrite existing files (combined with the PathBuf::join arbitrary file write vulnerability), or deploy malicious payloads to the system, leading to complete system compromise.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Include the following header: `Authorization: Bearer update_me_please`.
+4. Include form fields for `version` (e.g., `2.0.0`), `description`, and `changelog`, and attach a dummy file for the `file` field.
+5. Send the request.
+6. Observe that the server returns a `201 Created` status code and processes the upload successfully, despite the absence of a legitimately configured API key.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should fail securely if a critical secret like `AETHER_UPLOAD_KEY` is not present in the environment.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error: AETHER_UPLOAD_KEY missing".to_string()))?;
+```
+Alternatively, panic on startup if required configuration values are missing, ensuring the application cannot run in an insecure state.
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
This PR provides Sentinel's audit report for a CRITICAL Broken Authentication vulnerability found in the `upload_handler` (`syscore/src/server/aether.rs`). The system incorrectly falls back to a weak, hardcoded string (`"update_me_please"`) if the `AETHER_UPLOAD_KEY` environment variable is missing, allowing unauthorized access. 

The report has been appended to `SECURITY_ISSUE.md` per the requested template, and a journal entry has been added to `.jules/sentinel.md` outlining the systemic cause and auditor notes. 

No application code was modified, strictly adhering to the requested rules of engagement. All backend and frontend unit/integration tests remain passing.

---
*PR created automatically by Jules for task [12401606378938414198](https://jules.google.com/task/12401606378938414198) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a critical security advisory describing an authentication bypass in the file upload flow when a required secret is missing.
  * Included the impact, steps to reproduce, and recommended fix to remove insecure default credentials and fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->