### PR TITLE
Document Broken Auth vulnerability in Aether upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Hardcoded Fallback Credential in Aether Upload Handler
+Vulnerability Pattern: Weak default credential used as a fallback for missing environment variable `AETHER_UPLOAD_KEY`.
+Systemic Cause: The `upload_handler` attempts to handle the absence of the required API key by providing a default value (`"update_me_please"`) via `unwrap_or_else`, prioritizing service availability (or ease of development) over security.
+Auditor Note: Always check usages of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials. Ensure they fail securely rather than supplying weak default fallbacks that can be exploited in production.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,40 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded/Weak default fallback credential in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` uses a weak, hardcoded default API key (`"update_me_please"`) as a fallback if the `AETHER_UPLOAD_KEY` environment variable is not set.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This ensures that if the service is deployed without properly configuring the `AETHER_UPLOAD_KEY` secret, an attacker can easily bypass authentication by guessing or discovering this default key in the source code.
+
+🎯 Potential Impact
+An unauthenticated external attacker can use the default credential `"update_me_please"` to authenticate to the `/api/v1/aether` upload endpoint. This allows them to upload arbitrary application versions, bundles, and patches to the backend, effectively taking control of the software distribution channel. When combined with the Arbitrary File Write vulnerability, this leads to immediate remote code execution on the server.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a multipart POST request to the `/api/v1/aether` endpoint.
+3. Include the header `Authorization: Bearer update_me_please`.
+4. Observe that the server accepts the upload request and processes it, instead of rejecting it with a 401 Unauthorized status.
+
+✅ Recommended Remediation
+Remove the fallback default credential. The service should reject requests securely if the required environment variable is missing, or preferably fail to start.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY")
+    .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server configuration error".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Documented the Broken Auth vulnerability found in the Aether version upload handler, updating `SECURITY_ISSUE.md` with the vulnerability details and `.jules/sentinel.md` with the architectural learning.

---
*PR created automatically by Jules for task [4151100196800523681](https://jules.google.com/task/4151100196800523681) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the security audit notes with additional details on a path handling risk and a missing-environment fallback credential issue.
  * Added a new critical authentication vulnerability section, including impact, reproduction steps, and guidance for secure configuration.
  * Included references to relevant security standards and common weakness categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->