### PR TITLE
docs: Add security issue report for Aether upload auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-20 - Broken Auth Fallback in Aether Uploads
+Vulnerability Pattern: Hardcoded default fallback credential (`update_me_please`) when `AETHER_UPLOAD_KEY` is missing.
+Systemic Cause: The `upload_handler` uses `unwrap_or_else` on the environment variable representing a secret, defaulting to a weak known string instead of failing securely.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,41 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key for Aether uploads
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a weak default credential fallback.
+When the `AETHER_UPLOAD_KEY` environment variable is not set, the application uses `unwrap_or_else` to fallback to a hardcoded string `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+Because the default key is present in the source code, anyone with access to the source code can find it and use it to bypass authentication if the environment variable is not explicitly configured in production.
+
+🎯 Potential Impact
+An unauthenticated external attacker can use the default API key `"update_me_please"` to bypass authorization on the `/api/v1/aether` endpoint. This allows them to upload arbitrary Aether versions, which could lead to unauthorized file overwrites, distribution of malicious updates, or complete system compromise in combination with the Arbitrary File Write vulnerability.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Set the authentication header to the default fallback: `Authorization: Bearer update_me_please`.
+4. Send the request with required multipart fields (e.g., `version`, `file`).
+5. Observe that the request is accepted and the file is uploaded, successfully bypassing authentication.
+
+✅ Recommended Remediation
+Remove the weak default fallback. The application should fail securely if the environment variable is not provided, either by returning an error at startup or rejecting the request.
+
+Example fix:
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: AETHER_UPLOAD_KEY not set".to_string()))?;
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-10/2017/A2_2017-Broken_Authentication
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Add security issue report for Aether upload auth.

---
*PR created automatically by Jules for task [10650569272203599136](https://jules.google.com/task/10650569272203599136) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security finding to the security issue documentation, including impact, reproduction steps, and recommended remediation.
  * Expanded the recorded security notes with additional dated findings related to file handling and authentication fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->