### PR TITLE
🛡️ CRITICAL Broken Auth: Hardcoded default API key fallback in upload handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-24 - Broken Authentication in Aether Upload Handler
+Vulnerability Pattern: Hardcoded default credentials / Broken Auth fallback for critical API routes.
+Systemic Cause: The application uses a weak default string ("update_me_please") when the environment variable for an API key is missing, leaving endpoints exposed if not properly configured.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,40 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key fallback in upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` uses a weak default credential if the `AETHER_UPLOAD_KEY` environment variable is not set. Specifically, on line 118, it falls back to the hardcoded string `"update_me_please"`:
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+This means that if the application is deployed without the `AETHER_UPLOAD_KEY` explicitly configured, anyone can bypass authentication by simply providing `Bearer update_me_please` in the Authorization header.
+
+🎯 Potential Impact
+An unauthorized attacker can completely bypass authentication to the critical `/api/v1/aether` upload endpoint. By exploiting this, they can upload malicious payloads (e.g., in combination with the arbitrary file write vulnerability) or overwrite legitimate application versions, leading to a complete compromise of the system or supply chain attacks.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Construct a multipart POST request to the `/api/v1/aether` upload endpoint.
+3. Set the Authorization header to `Bearer update_me_please`.
+4. Observe that the server accepts the upload instead of returning a `401 Unauthorized`.
+
+✅ Recommended Remediation
+Remove the hardcoded default fallback for the API key. Instead, the application should fail securely. Either fail to start if the environment variable is missing, or return an authentication error if the variable is not set.
+
+Example fix:
+```rust
+let expected_key = match std::env::var("AETHER_UPLOAD_KEY") {
+    Ok(key) => key,
+    Err(_) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Server misconfiguration: missing upload key".to_string())),
+};
+```
+
+🔗 References
+- OWASP Broken Authentication: https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication


### PR DESCRIPTION
As Sentinel, I conducted a security audit of the codebase and identified a **CRITICAL Broken Authentication** vulnerability in `syscore/src/server/aether.rs`.

**Findings:**
The `upload_handler` falls back to a hardcoded string (`"update_me_please"`) if the `AETHER_UPLOAD_KEY` environment variable is not set. This allows anyone to bypass authentication to a critical system endpoint simply by knowing the default fallback.

**Actions Taken:**
1. Documented the finding as a professional GitHub Issue appended to `SECURITY_ISSUE.md`.
2. Followed the strict emoji template requested (Severity, Description, Impact, Reproduction, Remediation, References).
3. Recorded the architectural learning in `.jules/sentinel.md` under the required format.
4. Complied with all boundaries (did not modify code, did not commit secrets, verified findings by reading the actual source).

---
*PR created automatically by Jules for task [14379127316561129227](https://jules.google.com/task/14379127316561129227) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Documented a critical authentication issue affecting file uploads, including the risk of unauthorized access when a fallback API credential is used.
  * Added guidance on safer failure behavior and remediation steps.

* **Documentation**
  * Expanded security notes with an additional vulnerability entry covering file path handling risks and authentication weaknesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->