### PR TITLE
docs: Document CRITICAL Broken Auth vulnerability in Aether

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 Vulnerability Pattern: Arbitrary File Write via absolute path injection in `multipart.next_field().file_name()`.
 Systemic Cause: The `upload_handler` blindly trusts the `filename` provided in the HTTP multipart request without sanitization. In Rust, `PathBuf::join` completely replaces the base path if the appended string is an absolute path, leading to out-of-bounds file writes.
 Auditor Note: Always check usages of `PathBuf::join` with user-supplied strings, especially those extracted from multipart uploads, headers, or query parameters. Look for missing sanitization of path separators and absolute paths before path concatenation.
+## 2024-05-18 - Broken Auth in Aether Upload Handler
+Vulnerability Pattern: Weak hardcoded default credential for API authentication.
+Systemic Cause: The use of `unwrap_or_else` on an environment variable (`AETHER_UPLOAD_KEY`) falls back to a weak default string instead of failing securely when the secret is missing.
+Auditor Note: Systematically check for uses of `unwrap_or_else` or `unwrap_or` on environment variables representing secrets or credentials, ensuring they fail securely rather than supplying weak default fallbacks.

--- a/SECURITY_ISSUE.md
+++ b/SECURITY_ISSUE.md
@@ -46,3 +46,35 @@ let file_path = version_dir.join(safe_filename);
 🔗 References
 - Rust `PathBuf::join` documentation: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
 - OWASP Path Traversal / Arbitrary File Write: https://owasp.org/www-community/attacks/Path_Traversal
+
+Title: 🛡️ CRITICAL Broken Auth: Hardcoded default API key in Aether upload handler
+
+🚨 Severity
+CRITICAL
+
+💡 Description
+The `upload_handler` function in `syscore/src/server/aether.rs` contains a Broken Authentication vulnerability due to a hardcoded fallback credential. When the `AETHER_UPLOAD_KEY` environment variable is not set, the application defaults to the weak, hardcoded string `"update_me_please"`.
+
+```rust
+// syscore/src/server/aether.rs
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").unwrap_or_else(|_| "update_me_please".to_string());
+```
+
+🎯 Potential Impact
+An unauthorized attacker can trivially bypass authentication by using the default credential. They can then upload malicious binaries or patches, potentially distributing malware to clients downloading updates. Combined with other vulnerabilities, this can lead to complete system compromise.
+
+🛠️ Steps to Reproduce
+1. Start the `syscore` backend service without setting the `AETHER_UPLOAD_KEY` environment variable.
+2. Send a POST request to `/api/v1/aether` to upload a file.
+3. Include the HTTP header: `Authorization: Bearer update_me_please`.
+4. Observe that the request is successfully authenticated and processed, resulting in an unauthorized file upload.
+
+✅ Recommended Remediation
+Remove the hardcoded default fallback. If the `AETHER_UPLOAD_KEY` is missing, the application should either fail to start or the endpoint should explicitly deny all upload requests.
+
+```rust
+let expected_key = std::env::var("AETHER_UPLOAD_KEY").map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "AETHER_UPLOAD_KEY not configured".to_string()))?;
+```
+
+🔗 References
+- CWE-798: Use of Hard-coded Credentials: https://cwe.mitre.org/data/definitions/798.html


### PR DESCRIPTION
Documented a CRITICAL Broken Auth vulnerability in `syscore/src/server/aether.rs` where the `AETHER_UPLOAD_KEY` falls back to a hardcoded default string (`"update_me_please"`). Appended architectural learnings to `.jules/sentinel.md` and created a structured GitHub Issue report in `SECURITY_ISSUE.md`.

---
*PR created automatically by Jules for task [3979883132369082319](https://jules.google.com/task/3979883132369082319) started by @Vaiditya2207*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security notes covering two critical risks: unsafe handling of uploaded file paths and weak default credentials for uploads.
  * Clarified the impact of these issues and included guidance to safely reject missing credentials and avoid unsafe path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->